### PR TITLE
Fixed UndefinedProtocolTypeError for PySyft dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "tqdm==4.36.1",
         "mmh3==2.5.1",
-        "syft==0.2.3a2",
+        "syft==0.2.3.a3",
         "requests==2.22.0",
     ],
     extras_require={


### PR DESCRIPTION
Upgrades PySyft version to `0.2.3.a3` to avoid `UndefinedProtocolTypeError`.