### PR TITLE
Created SimpleTagger class

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "tqdm==4.36.1",
         "mmh3==2.5.1",
-        "syft==0.2.3.a3",
+        "syft==0.2.3",
         "requests==2.22.0",
     ],
     extras_require={

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -48,21 +48,8 @@ class Doc(AbstractObject):
         # Get the corresponding TokenMeta object
         token_meta = self.container[key]
 
-        # The start and stop positions of the token in self.text
-        # notice that stop_position refers to one position after `token_meta.end_pos`.
-        # this is practical for indexing
-        start_pos = token_meta.start_pos
-        stop_pos = token_meta.end_pos + 1 if token_meta.end_pos is not None else None
-
         # Create a Token object
-        token = Token(
-            doc=self,
-            # string = self.text[start_pos:end_pos],
-            start_pos=start_pos,
-            stop_pos=stop_pos,
-            is_space=token_meta.is_space,
-            space_after=token_meta.space_after,
-        )
+        token = Token(doc=self, token_meta=token_meta)
 
         return token
 

--- a/syfertext/pipeline/__init__.py
+++ b/syfertext/pipeline/__init__.py
@@ -1,0 +1,1 @@
+from .simple_tagger import SimpleTagger

--- a/syfertext/pipeline/simple_tagger.py
+++ b/syfertext/pipeline/simple_tagger.py
@@ -19,7 +19,7 @@ class SimpleTagger:
         default_tag: object = None,
         case_sensitive: bool = True,
     ):
-        """Initialize the TokenTagger object.
+        """Initialize the SimpleTagger object.
 
            Args:
                attribute (str): The name of the attribute that will hold the tag.

--- a/syfertext/pipeline/simple_tagger.py
+++ b/syfertext/pipeline/simple_tagger.py
@@ -1,0 +1,119 @@
+from syfertext.doc import Doc
+from syfertext.token import Token
+from typing import Union
+
+
+class SimpleTagger:
+    """This is a very simple token-level tagger. It enables to tag specified
+       tokens in a `Doc` object. By tagging a token, we mean setting a new
+       attribute to that token which holds the desired tag as its value.
+       The attribute becomes accessible then through the Underscore attribute
+       of the `Token` object.
+    """
+    
+    def __init__(
+        self,
+        attribute: str,
+        lookups: Union[set, list, dict],
+        tag: object = None,
+        default_tag: object = None,
+        case_sensitive: bool = True,
+    ):
+        """Initialize the TokenTagger object.
+
+           Args:
+               attribute (str): The name of the attribute that will hold the tag.
+                   this attribute will be accessible through the attribute
+                   `._` of Token objects. Example `token_object._.<attribute>
+               lookups (set, list or dict): If of type `list` of `set`, it should contain
+                   the tokens that are to be searched for and tagged in the Doc 
+                   object's text. Example: ['the', 'myself', ...]
+                   If of type `dict`, the keys should be the tokens texts to be
+                   tagged, and values should hold a single tag for each such token.
+                   Example: tagging stop words {'the': True, 'myself' : True}.
+               tag (object, optional): If `lookups` is of type `list`, then this
+                   will be the tag assigned to all matched tokens. It will be 
+                   ignored if `lookups` if of type `dict`.
+               default_tag: (object, optional): The default tag to be assigned
+                   in case the token text maches no entry in `lookups`.
+               case_sensitive: (bool, optional): If set to True, then matching
+                   token texts to `lookups` will become case sensitive.
+                   Defaults to True.
+        """
+
+        self.attribute = attribute
+
+        # Desensitize tokens in lookups if `case_sensitive` is False
+        if case_sensitive:
+            self.lookups = lookups
+        else:
+            self.lookups = self._desensitize_lookups(lookups)
+
+        # If `lookups` is a `list`, convert it to a `set`
+        self.lookups = (
+            set(self.lookups) if isinstance(self.lookups, list) else self.lookups
+        )
+
+        self.case_sensitive = case_sensitive
+        self.tag = tag
+        self.default_tag = default_tag
+
+    def __call__(self, doc: Doc):
+
+        # Start tagging
+        for token in doc:
+
+            # Get the tag
+            tag = self._get_tag(token)
+
+            # Set the attribute of each matched token to the tag
+            token.set_attribute(name=self.attribute, value=tag)
+
+    def _desensitize_lookups(self, lookups: Union[dict, list, set]):
+        """Converts every token in `self.lookups` to lower case to enable
+           case in-sensitive matching
+
+           Args:
+               lookups (set, list or dict): Check out the docstring of `__init__()`.
+
+           Returns:
+               A transformed version  of `lookup` where all token texts are in 
+               lower case.
+ 
+        """
+
+        # Replace dict keys with lower-case versions
+        if isinstance(lookups, dict):
+            return {token.lower(): lookups[token] for token in lookups}
+
+        # Convert all list or set elements to lower case
+        if isinstance(lookups, list) or isinstance(lookups, set):
+            return {token.lower() for token in lookups}
+
+    def _get_tag(self, token: Token):
+        """Gets the tag that should be assigned to the Token object `token`.
+           If now value is found, self.default is used instead
+
+
+           Args:
+               token (Token): The Token object to which the tag is to be assigned.
+
+           Returns:
+               tag (object): Check out the docstring of `__init__()`.
+        """
+
+        # Get the token text
+        token_text = token.text if self.case_sensitive else token.text.lower()
+
+        # If `self.lookups` is a dict, get the corresponding tag
+        if isinstance(self.lookups, dict):
+
+            # Get the associated tag
+            tag = self.lookups.get(token_text, self.default_tag)
+
+        # If `self.lookups` is a set, use the `self.tag` attribute.
+        elif isinstance(self.lookups, set):
+
+            tag = self.tag if token_text in self.lookups else self.default_tag
+
+        return tag

--- a/syfertext/pipeline/simple_tagger.py
+++ b/syfertext/pipeline/simple_tagger.py
@@ -10,7 +10,7 @@ class SimpleTagger:
        The attribute becomes accessible then through the Underscore attribute
        of the `Token` object.
     """
-    
+
     def __init__(
         self,
         attribute: str,

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -7,15 +7,24 @@ hook = sy.TorchHook(torch)
 
 
 class Token:
-    def __init__(
-        self, doc, start_pos: int, stop_pos: int, is_space: bool, space_after: bool
-    ):
+    def __init__(self, doc, token_meta: "TokenMeta"):
 
         self.doc = doc
-        self.start_pos = start_pos
-        self.stop_pos = stop_pos
-        self.is_space = is_space
-        self.space_after = space_after
+
+        # The start and stop positions of the token in self.text
+        # notice that stop_position refers to one position after `token_meta.end_pos`.
+        # this is practical for indexing
+        self.start_pos = token_meta.start_pos
+        self.stop_pos = (
+            token_meta.end_pos + 1 if token_meta.end_pos is not None else None
+        )
+        self.is_space = token_meta.is_space
+        self.space_after = token_meta.space_after
+
+        # Initialize the Underscore object (inspired by spaCy)
+        # This object will hold all the custom attributes et
+        # using the `self.set_attribute` method
+        self._ = token_meta._
 
         # Whether this token has a vector or not
         self.has_vector = self.doc.vocab.vectors.has_vector(self.text)
@@ -26,6 +35,13 @@ class Token:
         # when text is of type String or StringPointer (which are Syft string
         # types)
         return self.text
+
+    def set_attribute(self, name: str, value: object):
+        """Creates a custom attribute with the name `name` and
+           value `value` in the Underscore object `self._`
+        """
+
+        setattr(self._, name, value)
 
     @property
     def orth(self):

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -22,7 +22,7 @@ class Token:
         self.space_after = token_meta.space_after
 
         # Initialize the Underscore object (inspired by spaCy)
-        # This object will hold all the custom attributes et
+        # This object will hold all the custom attributes set
         # using the `self.set_attribute` method
         self._ = token_meta._
 

--- a/syfertext/tokenizer.py
+++ b/syfertext/tokenizer.py
@@ -1,5 +1,6 @@
 from .doc import Doc
 from .vocab import Vocab
+from .underscore import Underscore
 
 from syft.generic.object import AbstractObject
 from syft.workers.base import BaseWorker
@@ -10,26 +11,21 @@ from typing import List, Union
 
 
 class TokenMeta(object):
-
-    """
-       This class holds some meta data about a token from the text held by a Doc object.
+    """This class holds some meta data about a token from the text held by a Doc object.
        This allows to create a Token object when needed.
     """
 
     def __init__(self, start_pos: int, end_pos: int, space_after: bool, is_space: bool):
-        """
-           Parameters
-           ----------
-           start_pos: int
-                      The start index of the token in the Doc text.
+        """Initializes a TokenMeta object
 
-           end_pos: int
-                    The end index of the token in the Doc text (the end index is
-                    part of the token).
-           space_after: bool
-                        Whether the token is followed by a single white space (True) or not (False).
-           is_space: bool
-                     Whether the token itself is composed of only white spaces (True) or not (false).
+           Args:
+               start_pos (int): The start index of the token in the Doc text.
+               end_pos (int): The end index of the token in the Doc text (the end index is
+                   part of the token).
+               space_after (bool): Whether the token is followed by a single white 
+                   space (True) or not (False).
+               is_space (bool): Whether the token itself is composed of only white 
+                   spaces (True) or not (false).
 
         """
 
@@ -37,6 +33,11 @@ class TokenMeta(object):
         self.end_pos = end_pos
         self.space_after = space_after
         self.is_space = is_space
+
+        # Initialize the Underscore object (inspired by spaCy)
+        # This object will hold all the custom attributes et
+        # using the `self.set_attribute` method
+        self._ = Underscore()
 
 
 class Tokenizer(AbstractObject):

--- a/syfertext/tokenizer.py
+++ b/syfertext/tokenizer.py
@@ -35,7 +35,7 @@ class TokenMeta(object):
         self.is_space = is_space
 
         # Initialize the Underscore object (inspired by spaCy)
-        # This object will hold all the custom attributes et
+        # This object will hold all the custom attributes set
         # using the `self.set_attribute` method
         self._ = Underscore()
 

--- a/syfertext/underscore.py
+++ b/syfertext/underscore.py
@@ -1,0 +1,6 @@
+class Underscore:
+    """Objects of this class will hold custom attributes of Token
+       objects set using the `set_attribute` method of the Token 
+       class
+    """
+    pass

--- a/syfertext/underscore.py
+++ b/syfertext/underscore.py
@@ -3,4 +3,5 @@ class Underscore:
        objects set using the `set_attribute` method of the Token 
        class
     """
+
     pass

--- a/tests/local_mode/test_simple_tagger.py
+++ b/tests/local_mode/test_simple_tagger.py
@@ -1,0 +1,104 @@
+import pytest
+import syft
+import torch
+import syfertext
+from syfertext.pipeline import SimpleTagger
+
+# Create a torch hook for PySyft
+hook = syft.TorchHook(torch)
+
+# Get a reference to the local worker
+me = hook.local_worker
+
+# Get a SyferText Language object
+nlp = syfertext.load("en_core_web_lg", owner = me)
+
+# Define a text to tag
+text = 'The quiCk broWn Fox jUmps over thE lazY Dog . I will tokenizE thiS phrase wiTh SyferText . I Will do it myselF'
+
+# Create dictionary lookups
+dict_lookups = [ ({'The': True, 'myselF': True, 'jumps': 'verb', 'with': 'prep'}, False, True), 
+                 ({'The': True, 'myselF': True, 'jumps': 'verb', 'with': 'prep'}, False, False), 
+                 ({}, 'tag me', True), # This is supposed to tag all words with the same tag 'tag me'
+                 ({}, 'tag me', False), # This is supposed to tag all words with the same tag 'tag me'                 
+]
+
+list_set_lookups = [ (['The', 'myselF', 'jumps', 'with'], True, False, True), 
+                     (['The', 'myselF', 'jumps', 'with'], 'hey', False, False), 
+                     ([], 'tag1', 'tag2', True), 
+                     ([], 'tag1', 'tag2', False), 
+                     ({'The', 'myselF', 'jumps', 'with'}, True, False, True), 
+                     ({'The', 'myselF', 'jumps', 'with'}, 'hey', False, False), 
+                     ({}, 'tag1', 'tag2', True), 
+                     ({}, 'tag1', 'tag2', False), 
+]
+
+
+@pytest.mark.parametrize("lookups,default_tag,case_sensitive", dict_lookups)
+def test_simple_tagger_with_dict(lookups, default_tag, case_sensitive):
+
+    # Create the document
+    doc = nlp(text)
+    
+    # Create the tagger
+    tagger = SimpleTagger(attribute= 'custom_tag',
+                          lookups= lookups,
+                          case_sensitive= case_sensitive,
+                          tag= "don't care", # This will be ignored since a dict lookup is used
+                          default_tag= default_tag)
+
+
+    # Tag the document
+    tagger(doc)
+
+    # Adjust the lookups for case insensitive cases
+    if not case_sensitive:
+        lookups = {key.lower(): lookups[key] for key in lookups}
+
+    # Check if tags were successfully stored in the specified attribute
+    for token in doc:
+
+        # Get the token text
+        token_text = token.text if case_sensitive else token.text.lower()
+        
+        if token_text in lookups:
+            assert token._.custom_tag == lookups[token_text]
+        else:
+            assert token._.custom_tag == default_tag
+
+
+
+@pytest.mark.parametrize("lookups,tag,default_tag,case_sensitive", list_set_lookups)
+def test_simple_tagger_with_lists_sets(lookups, tag, default_tag, case_sensitive):
+
+    # Create the document
+    doc = nlp(text)
+    
+    # Create the tagger
+    tagger = SimpleTagger(attribute= 'custom_tag',
+                          lookups= lookups,
+                          case_sensitive= case_sensitive,
+                          tag= tag, # This will be ignored since a dict lookup is used
+                          default_tag= default_tag)
+
+
+    # Tag the document
+    tagger(doc)
+
+    # Adjust the lookups for case insensitive cases
+    if not case_sensitive:
+        lookups = {string.lower() for string in lookups}
+
+    # Check if tags were successfully stored in the specified attribute
+    for token in doc:
+
+        # Get the token text
+        token_text = token.text if case_sensitive else token.text.lower()
+        
+        if token_text in lookups:
+            assert token._.custom_tag == tag
+        else:
+            assert token._.custom_tag == default_tag
+                     
+
+    

--- a/tests/local_mode/test_simple_tagger.py
+++ b/tests/local_mode/test_simple_tagger.py
@@ -89,7 +89,7 @@ def test_simple_tagger_with_lists_sets(lookups, tag, default_tag, case_sensitive
         attribute="custom_tag",
         lookups=lookups,
         case_sensitive=case_sensitive,
-        tag=tag,  # This will be ignored since a dict lookup is used
+        tag=tag,
         default_tag=default_tag,
     )
 

--- a/tests/local_mode/test_simple_tagger.py
+++ b/tests/local_mode/test_simple_tagger.py
@@ -11,26 +11,36 @@ hook = syft.TorchHook(torch)
 me = hook.local_worker
 
 # Get a SyferText Language object
-nlp = syfertext.load("en_core_web_lg", owner = me)
+nlp = syfertext.load("en_core_web_lg", owner=me)
 
 # Define a text to tag
-text = 'The quiCk broWn Fox jUmps over thE lazY Dog . I will tokenizE thiS phrase wiTh SyferText . I Will do it myselF'
+text = "The quiCk broWn Fox jUmps over thE lazY Dog . I will tokenizE thiS phrase wiTh SyferText . I Will do it myselF"
 
 # Create dictionary lookups
-dict_lookups = [ ({'The': True, 'myselF': True, 'jumps': 'verb', 'with': 'prep'}, False, True), 
-                 ({'The': True, 'myselF': True, 'jumps': 'verb', 'with': 'prep'}, False, False), 
-                 ({}, 'tag me', True), # This is supposed to tag all words with the same tag 'tag me'
-                 ({}, 'tag me', False), # This is supposed to tag all words with the same tag 'tag me'                 
+dict_lookups = [
+    ({"The": True, "myselF": True, "jumps": "verb", "with": "prep"}, False, True),
+    ({"The": True, "myselF": True, "jumps": "verb", "with": "prep"}, False, False),
+    (
+        {},
+        "tag me",
+        True,
+    ),  # This is supposed to tag all words with the same tag 'tag me'
+    (
+        {},
+        "tag me",
+        False,
+    ),  # This is supposed to tag all words with the same tag 'tag me'
 ]
 
-list_set_lookups = [ (['The', 'myselF', 'jumps', 'with'], True, False, True), 
-                     (['The', 'myselF', 'jumps', 'with'], 'hey', False, False), 
-                     ([], 'tag1', 'tag2', True), 
-                     ([], 'tag1', 'tag2', False), 
-                     ({'The', 'myselF', 'jumps', 'with'}, True, False, True), 
-                     ({'The', 'myselF', 'jumps', 'with'}, 'hey', False, False), 
-                     ({}, 'tag1', 'tag2', True), 
-                     ({}, 'tag1', 'tag2', False), 
+list_set_lookups = [
+    (["The", "myselF", "jumps", "with"], True, False, True),
+    (["The", "myselF", "jumps", "with"], "hey", False, False),
+    ([], "tag1", "tag2", True),
+    ([], "tag1", "tag2", False),
+    ({"The", "myselF", "jumps", "with"}, True, False, True),
+    ({"The", "myselF", "jumps", "with"}, "hey", False, False),
+    ({}, "tag1", "tag2", True),
+    ({}, "tag1", "tag2", False),
 ]
 
 
@@ -39,14 +49,15 @@ def test_simple_tagger_with_dict(lookups, default_tag, case_sensitive):
 
     # Create the document
     doc = nlp(text)
-    
-    # Create the tagger
-    tagger = SimpleTagger(attribute= 'custom_tag',
-                          lookups= lookups,
-                          case_sensitive= case_sensitive,
-                          tag= "don't care", # This will be ignored since a dict lookup is used
-                          default_tag= default_tag)
 
+    # Create the tagger
+    tagger = SimpleTagger(
+        attribute="custom_tag",
+        lookups=lookups,
+        case_sensitive=case_sensitive,
+        tag="don't care",  # This will be ignored since a dict lookup is used
+        default_tag=default_tag,
+    )
 
     # Tag the document
     tagger(doc)
@@ -60,12 +71,11 @@ def test_simple_tagger_with_dict(lookups, default_tag, case_sensitive):
 
         # Get the token text
         token_text = token.text if case_sensitive else token.text.lower()
-        
+
         if token_text in lookups:
             assert token._.custom_tag == lookups[token_text]
         else:
             assert token._.custom_tag == default_tag
-
 
 
 @pytest.mark.parametrize("lookups,tag,default_tag,case_sensitive", list_set_lookups)
@@ -73,14 +83,15 @@ def test_simple_tagger_with_lists_sets(lookups, tag, default_tag, case_sensitive
 
     # Create the document
     doc = nlp(text)
-    
-    # Create the tagger
-    tagger = SimpleTagger(attribute= 'custom_tag',
-                          lookups= lookups,
-                          case_sensitive= case_sensitive,
-                          tag= tag, # This will be ignored since a dict lookup is used
-                          default_tag= default_tag)
 
+    # Create the tagger
+    tagger = SimpleTagger(
+        attribute="custom_tag",
+        lookups=lookups,
+        case_sensitive=case_sensitive,
+        tag=tag,  # This will be ignored since a dict lookup is used
+        default_tag=default_tag,
+    )
 
     # Tag the document
     tagger(doc)
@@ -94,11 +105,8 @@ def test_simple_tagger_with_lists_sets(lookups, tag, default_tag, case_sensitive
 
         # Get the token text
         token_text = token.text if case_sensitive else token.text.lower()
-        
+
         if token_text in lookups:
             assert token._.custom_tag == tag
         else:
             assert token._.custom_tag == default_tag
-                     
-
-    


### PR DESCRIPTION
## Description

I added a class called `SimpleTagger` in a new module called `pipeline`. This object can be called on a `Doc` object. It creates a custom attribute for each of its tokens. This attributes holds a tag. The tokens to be tagged are specified in the initialization of the `SimpleTagger` object.

Example usage:

```
# Import the SimpleTagger object
from syfertext.pipeline import SimpleTagger

# Tokenize a string
doc = nlp("I liKe things")

# Initialize the tagger
tagger = SimpleTagger(attribute= 'is_stop',
                                     lookups= {"I": 'net', 'liKe': 2},
                                     case_sensitive= True,
                                     tag=True,
                                     default_tag='unknown')

# Tag the document
tagger(doc)

print(doc[0]._.is_stop)
# output: 'net'

print(doc[2]._.is_stop)
# output: 'unknown'
```
This class can be useful in order to mark certain tokens as stop words for instance. This is just an example but the possibilities are numerous.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `tests/local_mode/test_simple_tagger_with_dict()`
- [x] `testst/local_mode/test_simple_tagger_with_list_set()`

## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [x] I have added tests for my changes