### PR TITLE
[WIP] change text attribute usage in Doc

### DIFF
--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -20,6 +20,7 @@ class Token:
         )
         self.is_space = token_meta.is_space
         self.space_after = token_meta.space_after
+        self.text = token_meta.token_text
 
         # Initialize the Underscore object (inspired by spaCy)
         # This object will hold all the custom attributes set
@@ -47,11 +48,6 @@ class Token:
     def orth(self):
         """Get the corresponding hash value of this token"""
         return hash_string(str(self))
-
-    @property
-    def text(self):
-        """Get the token text"""
-        return str(self.doc.text[self.start_pos : self.stop_pos])
 
     @property
     def vector(self):

--- a/syfertext/tokenizer.py
+++ b/syfertext/tokenizer.py
@@ -15,7 +15,7 @@ class TokenMeta(object):
        This allows to create a Token object when needed.
     """
 
-    def __init__(self, start_pos: int, end_pos: int, space_after: bool, is_space: bool):
+    def __init__(self, token_text: str, start_pos: int, end_pos: int, space_after: bool, is_space: bool):
         """Initializes a TokenMeta object
 
            Args:
@@ -29,6 +29,7 @@ class TokenMeta(object):
 
         """
 
+        self.token_text = token_text
         self.start_pos = start_pos
         self.end_pos = end_pos
         self.space_after = space_after
@@ -155,6 +156,7 @@ class Tokenizer(AbstractObject):
                 # Create the TokenMeta object that can be later used to retrieve the token
                 # from the text
                 token_meta = TokenMeta(
+                    token_text=text[pos:i],
                     start_pos=pos,
                     end_pos=i - 1,
                     space_after=is_current_space,
@@ -183,6 +185,7 @@ class Tokenizer(AbstractObject):
                 # Create the TokenMeta object that can be later used to retrieve the token
                 # from the text
                 token_meta = TokenMeta(
+                    token_text=text[pos:],
                     start_pos=pos,
                     end_pos=None,  # text[pos:None] ~ text[pos:]
                     space_after=is_current_space,
@@ -191,6 +194,8 @@ class Tokenizer(AbstractObject):
 
                 # Append the token to the document
                 doc.container.append(token_meta)
+        # After filling Doc object container, we delete Doc object text to save memory
+        doc.text = None
 
         # If the Language object using this tokenizer lives on a different worker
         # (self.client_id != self.owner.id)


### PR DESCRIPTION
# Pull Request Template

## Description

I change text usage in Doc class.
During  creation container with TokenMeta objects, I provide every TokenMeta(and then Token) object with text attribute.
After creation, I change Doc().text to None. So, I decrease memory consumption and save text for further usage.
 

If your pull request closes a GitHub issue, then set its number below.

Fixes #27  

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- NOT YET.
I will add them after I find out rules of testing from community in Slack

## Checklist:

* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [ ] I have added tests for my changes. (NOT YET)