### PR TITLE
fixed issue Add support for adding custom attribute to Doc objects

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -35,12 +35,20 @@ class Doc(AbstractObject):
         self.container = list()
 
 
+    def __str__(self):
+
+        # The call to `str()` in the following is to account for the case
+        # when text is of type String or StringPointer (which are Syft string
+        # types)
+        return self.text
+
+
     def set_attribute(self, name: str, value: object):
         """Creates a custom attribute with the name `name` and the
            value `value` in the Underscore object `self._`
         """
 
-        return setattr(self._, name, value)
+        setattr(self._, name, value)
 
     def __getitem__(self, key: int):
         """Returns a Token object at position `key`.

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -34,6 +34,14 @@ class Doc(AbstractObject):
         # file
         self.container = list()
 
+
+    def set_attribute(self, name: str, value: object):
+        """Creates a custom attribute with the name `name` and
+           value `value` in the Underscore object `self._`
+        """
+
+        setattr(self._, name, value)
+
     def __getitem__(self, key: int):
         """Returns a Token object at position `key`.
 
@@ -45,16 +53,12 @@ class Doc(AbstractObject):
             Token: the token at index key
         """
 
+
         # Get the corresponding TokenMeta object
         token_meta = self.container[key]
 
         # Create a Token object
-        doc = nlp("Tokenize me")
-        token = doc[1]
-
-        token.set_attribute(name="custom_att", value='tag')
         token = Token(doc=self, token_meta=token_meta)
-
         return token
 
     @staticmethod

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -37,7 +37,7 @@ class Doc(AbstractObject):
                 # Initialize the Underscore object (inspired by spaCy)
         # This object will hold all the custom attributes set
         # using the `self.set_attribute` method
-        self._ = Underscore() 
+        self._ = Underscore()
 
 
     def __str__(self):
@@ -48,11 +48,20 @@ class Doc(AbstractObject):
         # types)
         return self.text
 
-
-    def set_attribute(self, name: str, value: object):
-        """Creates a custom attribute with the name `name` and the
+def set_attribute(self, name: str, value: object):
+        """Created a custom attribute with the name `name` and
            value `value` in the Underscore object `self._`
+        Args:
+            name (str): name of the custom attribute .
+            value (object): value of the custom named attribute.
         """
+
+        # make sure there is no space in name as well prevent empty name
+        assert type(name) is str, "name must be of str type"
+        assert (
+            len(name) > 0 and (not (" " in name)) and (type(name) == str)
+        ),
+        "name cannot be empty or contain space"
 
         setattr(self._, name, value)
 

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -40,7 +40,7 @@ class Doc(AbstractObject):
            value `value` in the Underscore object `self._`
         """
 
-        setattr(self._, name, value)
+        return setattr(self._, name, value)
 
     def __getitem__(self, key: int):
         """Returns a Token object at position `key`.

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -49,6 +49,10 @@ class Doc(AbstractObject):
         token_meta = self.container[key]
 
         # Create a Token object
+        doc = nlp("Tokenize me")
+        token = doc[1]
+
+        token.set_attribute(name="custom_att", value='tag')
         token = Token(doc=self, token_meta=token_meta)
 
         return token

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -9,6 +9,7 @@ from syft.workers.base import BaseWorker
 
 from typing import List
 from typing import Union
+from .underscore import Underscore
 
 
 class Doc(AbstractObject):
@@ -33,9 +34,14 @@ class Doc(AbstractObject):
         # Its members are objects of the TokenMeta class defined in the tokenizer.py
         # file
         self.container = list()
+                # Initialize the Underscore object (inspired by spaCy)
+        # This object will hold all the custom attributes set
+        # using the `self.set_attribute` method
+        self._ = Underscore() 
 
 
     def __str__(self):
+
 
         # The call to `str()` in the following is to account for the case
         # when text is of type String or StringPointer (which are Syft string

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -36,7 +36,7 @@ class Doc(AbstractObject):
 
 
     def set_attribute(self, name: str, value: object):
-        """Creates a custom attribute with the name `name` and
+        """Creates a custom attribute with the name `name` and the
            value `value` in the Underscore object `self._`
         """
 

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -41,7 +41,7 @@ class Token:
            value `value` in the Underscore object `self._`
         """
 
-         return setattr(self._, name, value)
+        setattr(self._, name, value)
 
     @property
     def orth(self):

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -41,7 +41,7 @@ class Token:
            value `value` in the Underscore object `self._`
         """
 
-        setattr(self._, name, value)
+         return setattr(self._, name, value)
 
     @property
     def orth(self):


### PR DESCRIPTION
Add support for adding custom attribute to Doc objects

## Description

Change the code as described.

If your pull request closes a GitHub issue, then set its number below.

Fixes # 30

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [ ] I have added tests for my changes