### PR TITLE
added custom attr

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -44,6 +44,10 @@ class Doc(AbstractObject):
         """Creates a custom attribute with the name `name` and
            value `value` in the Underscore object `self._`
         """
+
+        # make sure there is no space in name as well prevent empty name
+        assert(len(name) > 0 and (not(' ' in name)))
+
         setattr(self._, name, value)
 
     def __getitem__(self, key: int):

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -45,15 +45,14 @@ class Doc(AbstractObject):
            value `value` in the Underscore object `self._`
 
         Args:
-            name (str): name of the custom attribute .
+            name (str): name of the custom attribute.
             value (object): value of the custom named attribute.
         """
 
         # make sure there is no space in name as well prevent empty name
-        assert type(name) is str, "name must be of str type"
         assert (
-            len(name) > 0 and (not (" " in name)) and (type(name) == str)
-        ), "name cannot be empty or contain space"
+            isinstance(name, str) and len(name) > 0 and (not (" " in name))
+        ), "Argument name should be a non-empty str type containing no spaces"
 
         setattr(self._, name, value)
 

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -9,6 +9,7 @@ from syft.workers.base import BaseWorker
 
 from typing import List
 from typing import Union
+from .underscore import Underscore
 
 
 class Doc(AbstractObject):
@@ -33,6 +34,17 @@ class Doc(AbstractObject):
         # Its members are objects of the TokenMeta class defined in the tokenizer.py
         # file
         self.container = list()
+
+        # Initialize the Underscore object (inspired by spaCy)
+        # This object will hold all the custom attributes set
+        # using the `self.set_attribute` method
+        self._ = Underscore() 
+    
+    def set_attribute(self, name: str, value: object):
+        """Creates a custom attribute with the name `name` and
+           value `value` in the Underscore object `self._`
+        """
+        setattr(self._, name, value)
 
     def __getitem__(self, key: int):
         """Returns a Token object at position `key`.

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -38,8 +38,8 @@ class Doc(AbstractObject):
         # Initialize the Underscore object (inspired by spaCy)
         # This object will hold all the custom attributes set
         # using the `self.set_attribute` method
-        self._ = Underscore() 
-    
+        self._ = Underscore()
+
     def set_attribute(self, name: str, value: object):
         """Creates a custom attribute with the name `name` and
            value `value` in the Underscore object `self._`
@@ -51,7 +51,7 @@ class Doc(AbstractObject):
         """
 
         # make sure there is no space in name as well prevent empty name
-        assert(len(name) > 0 and (not(' ' in name)))
+        assert len(name) > 0 and (not (" " in name))
 
         setattr(self._, name, value)
 

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -43,6 +43,11 @@ class Doc(AbstractObject):
     def set_attribute(self, name: str, value: object):
         """Creates a custom attribute with the name `name` and
            value `value` in the Underscore object `self._`
+
+        Args:
+            self (Doc): current Doc.
+            name (str): name of the custom attribute .
+            value (object): value of the custom named attribute.
         """
 
         # make sure there is no space in name as well prevent empty name

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -45,13 +45,15 @@ class Doc(AbstractObject):
            value `value` in the Underscore object `self._`
 
         Args:
-            self (Doc): current Doc.
             name (str): name of the custom attribute .
             value (object): value of the custom named attribute.
         """
 
         # make sure there is no space in name as well prevent empty name
-        assert len(name) > 0 and (not (" " in name))
+        assert type(name) is str, "name must be of str type"
+        assert (
+            len(name) > 0 and (not (" " in name)) and (type(name) == str)
+        ), "name cannot be empty or contain space"
 
         setattr(self._, name, value)
 

--- a/tests/local_mode/test_custom_doc_attr.py
+++ b/tests/local_mode/test_custom_doc_attr.py
@@ -14,4 +14,4 @@ def test_add_custom_attr_doc():
     doc.set_attribute(name = 'my_custom_tag', value = 'tag')
     
     # check custom tag has been added
-    assert (doc._.my_custom_tag == 'tag')
+    assert (hasattr(doc._,'my_custom_tag') and doc._.my_custom_tag == 'tag')

--- a/tests/local_mode/test_custom_doc_attr.py
+++ b/tests/local_mode/test_custom_doc_attr.py
@@ -1,0 +1,17 @@
+import syft as sy
+import torch
+import syfertext
+
+hook = sy.TorchHook(torch)
+me = hook.local_worker
+
+nlp = syfertext.load("en_core_web_lg", owner=me)
+
+def test_add_custom_attr_doc():
+    """Test adding custom attribute to Doc objects"""
+    
+    doc = nlp("Joey doesnt share food")
+    doc.set_attribute(name = 'my_custom_tag', value = 'tag')
+    
+    # check custom tag has been added
+    assert (doc._.my_custom_tag == 'tag')

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -16,4 +16,16 @@ def test_add_custom_attr_doc():
     # check custom tag has been added
     assert (hasattr(doc._,'my_custom_tag') and doc._.my_custom_tag == 'tag')
 
+
+def test_update_custom_attr_doc():
+    """Test updating custom attribute of Doc objects"""
+
+    doc = nlp("Joey doesnt share food")
+    doc.set_attribute(name = 'my_custom_tag', value = 'tag')
     
+    # check custom tag has been added
+    assert (hasattr(doc._,'my_custom_tag') and doc._.my_custom_tag == 'tag')
+
+    doc.set_attribute(name = 'my_custom_tag', value = 'new_tag')
+
+    assert (hasattr(doc._,'my_custom_tag') and doc._.my_custom_tag == 'new_tag')

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -12,9 +12,11 @@ def test_add_custom_attr_doc():
     """Test adding custom attribute to Doc objects"""
 
     doc = nlp("Joey doesnt share food")
+
+    # add new custom attribute
     doc.set_attribute(name="my_custom_tag", value="tag")
 
-    # check custom tag has been added
+    # check custom attribute has been added
     assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "tag"
 
 
@@ -22,11 +24,15 @@ def test_update_custom_attr_doc():
     """Test updating custom attribute of Doc objects"""
 
     doc = nlp("Joey doesnt share food")
+
+    # add new custom attribute
     doc.set_attribute(name="my_custom_tag", value="tag")
 
-    # check custom tag has been added
+    # check custom attribute has been added
     assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "tag"
 
+    # now update the attribute
     doc.set_attribute(name="my_custom_tag", value="new_tag")
 
+    # now check the updated attribute
     assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "new_tag"

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -7,25 +7,26 @@ me = hook.local_worker
 
 nlp = syfertext.load("en_core_web_lg", owner=me)
 
+
 def test_add_custom_attr_doc():
     """Test adding custom attribute to Doc objects"""
-    
+
     doc = nlp("Joey doesnt share food")
-    doc.set_attribute(name = 'my_custom_tag', value = 'tag')
-    
+    doc.set_attribute(name="my_custom_tag", value="tag")
+
     # check custom tag has been added
-    assert (hasattr(doc._,'my_custom_tag') and doc._.my_custom_tag == 'tag')
+    assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "tag"
 
 
 def test_update_custom_attr_doc():
     """Test updating custom attribute of Doc objects"""
 
     doc = nlp("Joey doesnt share food")
-    doc.set_attribute(name = 'my_custom_tag', value = 'tag')
-    
+    doc.set_attribute(name="my_custom_tag", value="tag")
+
     # check custom tag has been added
-    assert (hasattr(doc._,'my_custom_tag') and doc._.my_custom_tag == 'tag')
+    assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "tag"
 
-    doc.set_attribute(name = 'my_custom_tag', value = 'new_tag')
+    doc.set_attribute(name="my_custom_tag", value="new_tag")
 
-    assert (hasattr(doc._,'my_custom_tag') and doc._.my_custom_tag == 'new_tag')
+    assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "new_tag"

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -15,3 +15,5 @@ def test_add_custom_attr_doc():
     
     # check custom tag has been added
     assert (hasattr(doc._,'my_custom_tag') and doc._.my_custom_tag == 'tag')
+
+    


### PR DESCRIPTION
## Description
Add support for adding custom attribute to Doc objects

Fixes #30  

## Type of change

Please mark options that are relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
```python
me = hook.local_worker
nlp = syfertext.load('en_core_web_lg', owner = me)
doc = nlp("Tokenize me")
doc.set_attribute(name = 'hello', value = 'tag')
print(doc._.hello)
#output tag
```

## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [x] I have added tests for my changes