### PR TITLE
[WIP] Custom-attribute-based token vector exclusion in computing Doc vector

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -197,6 +197,13 @@ class Doc(AbstractObject):
 
         return doc_vector
 
-    def exclude_tokens(self, exclude: dict = None, inplace=True):
-        if inplace:
-            self.excluded_tokens = exclude
+    def get_excluded_tokens(self):
+        return self._excluded_tokens
+
+    def set_excluded_tokens(self, excluded_tokens: dict = None):
+        self._excluded_tokens = excluded_tokens
+
+    def del_excluded_tokens(self):
+        del self._excluded_tokens
+
+    excluded_tokens = property(get_encrypted_vector, set_excluded_tokens, del_excluded_tokens)

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -119,13 +119,12 @@ class Doc(AbstractObject):
             # Yield a Token object
             yield self[i]
 
-    @property
-    def vector(self):
+    def get_vector(self, excluded_tokens: dict = None):
         """
         Get document vector as an average of in-vocabulary token's vectors
 
         Returns:
-          doc_vector: document vector
+            doc_vector: document vector
         """
 
         # Accumulate the vectors here
@@ -135,6 +134,15 @@ class Doc(AbstractObject):
         vector_count = 0
 
         for token in self:
+            if isinstance(excluded_tokens, dict):  # Check if token has attribute to be excluded
+                # TODO: Add Support for lists
+                values = [getattr(token._, attribute, None) for attribute in excluded_tokens.keys()]
+                bools = [
+                    value in exclude_value
+                    for value, exclude_value in zip(values, excluded_tokens.values())
+                ]
+                if any(bools):
+                    continue
 
             # Get the vector of the token if one exists
             if token.has_vector:
@@ -153,6 +161,8 @@ class Doc(AbstractObject):
             doc_vector = vectors / vector_count
 
         return doc_vector
+
+    vector = property(get_vector)
 
     def get_encrypted_vector(
         self, *workers: BaseWorker, crypto_provider: BaseWorker = None, requires_grad: bool = True

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -21,6 +21,7 @@ class Doc(AbstractObject):
         owner: BaseWorker = None,
         tags: List[str] = None,
         description: str = None,
+        excluded_tokens: dict = None,
     ):
 
         super(Doc, self).__init__(id=id, owner=owner, tags=tags, description=description)
@@ -37,6 +38,8 @@ class Doc(AbstractObject):
         # This object will hold all the custom attributes set
         # using the `self.set_attribute` method
         self._ = Underscore()
+
+        self._excluded_tokens = excluded_tokens
 
     def set_attribute(self, name: str, value: object):
         """Creates a custom attribute with the name `name` and
@@ -193,3 +196,7 @@ class Doc(AbstractObject):
         )
 
         return doc_vector
+
+    def exclude_tokens(self, exclude: dict = None, inplace=True):
+        if inplace:
+            self.excluded_tokens = exclude

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -136,6 +136,12 @@ class Doc(AbstractObject):
         # Count the tokens that have vectors
         vector_count = 0
 
+        excluded_tokens = (
+            {**self.excluded_tokens, **excluded_tokens}
+            if excluded_tokens is not None
+            else self.excluded_tokens
+        )
+
         for token in self:
             if isinstance(excluded_tokens, dict):  # Check if token has attribute to be excluded
                 # TODO: Add Support for lists
@@ -206,4 +212,4 @@ class Doc(AbstractObject):
     def del_excluded_tokens(self):
         del self._excluded_tokens
 
-    excluded_tokens = property(get_encrypted_vector, set_excluded_tokens, del_excluded_tokens)
+    excluded_tokens = property(get_excluded_tokens, set_excluded_tokens, del_excluded_tokens)

--- a/syfertext/language.py
+++ b/syfertext/language.py
@@ -92,7 +92,7 @@ class Language(AbstractObject):
 
         super(Language, self).__init__(id=id, owner=owner, tags=tags, description=description)
 
-    def make_doc(self, text: Union[str, String, StringPointer]):
+    def make_doc(self, text: Union[str, String, StringPointer], excluded_tokens):
         """Creates a Tokenizer object and uses it to tokenize 'text'. The tokens
         are stored in a Doc object which is then returned.
         """
@@ -117,19 +117,19 @@ class Language(AbstractObject):
             if isinstance(text, StringPointer) and text.location != self.owner:
                 self.tokenizers[location_id] = self.tokenizers[location_id].send(text.location)
 
-        doc = self.tokenizers[location_id](text)
+        doc = self.tokenizers[location_id](text, excluded_tokens=excluded_tokens)
 
         # Return the Doc object containing the tokens
         return doc
 
-    def __call__(self, text: Union[str, String, StringPointer]):
+    def __call__(self, text: Union[str, String, StringPointer], excluded_tokens: dict = None):
         """Here is where the real work is done. The pipeline components
         are called here, and the Doc object containing their results is created
         here too.
         """
 
         # create the Doc object with the tokenized text in it
-        doc = self.make_doc(text)
+        doc = self.make_doc(text, excluded_tokens)
 
         # TODO: Other pipline components should be called here and attach
         # their results to tokens in 'doc'

--- a/syfertext/tokenizer.py
+++ b/syfertext/tokenizer.py
@@ -82,7 +82,9 @@ class Tokenizer(AbstractObject):
 
         super(Tokenizer, self).__init__(id=id, owner=owner, tags=tags, description=description)
 
-    def __call__(self, text: Union[String, str] = None, text_id: int = None):
+    def __call__(
+        self, text: Union[String, str] = None, text_id: int = None, excluded_tokens: dict = None
+    ):
         """The real tokenization procedure takes place here.
 
            As in the spaCy library. This is not exactly equivalent to
@@ -120,7 +122,7 @@ class Tokenizer(AbstractObject):
         if text is None:
             text = self.owner.get_obj(text_id)
 
-        doc = Doc(self.vocab, text, owner=self.owner)
+        doc = Doc(self.vocab, text, owner=self.owner, excluded_tokens=excluded_tokens)
 
         # The number of characters in the text
         text_size = len(text)


### PR DESCRIPTION
# Pull Request Template

## Description
Exclude specific token vectors based on attributes
I have incorporated 2 methods of excluding tokens
1. ```doc.get_vector(excluded_tokens={"custom": ["pronoun"]})```
2. ```doc = nlp("on your left", excluded_tokens={"custom": ["pronoun"]})```

Raises Warning if custom attribute not present
Fixes #43 

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Method "2" of excluding tokens as mentioned above is broken for distributed mode
- [ ] This change requires a documentation update

## How Has This Been Tested?
WIP

## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [ ] I have added tests for my changes