### PR TITLE
added the get_vector() method with excluded_tokens argument

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -4,6 +4,7 @@ import torch
 
 hook = syft.TorchHook(torch)
 
+from typing import Dict
 from syft.generic.object import AbstractObject
 from syft.workers.base import BaseWorker
 
@@ -154,8 +155,55 @@ class Doc(AbstractObject):
 
         return doc_vector
 
+    def get_vector(self, excluded_tokens: Dict = None):
+        """
+        Get document vector as an average of in-vocabulary token's vectors,
+        excluding token according to the excluded_tokens dictionary.
+
+        Args
+            excluded_tokens (Dict): A dictionary used to ignore tokens of the document based on values of their attributes,
+                                    the keys are the attributes names and they index lists values.
+                                        Example: {'attribute1_name' : [value1, value2],
+                                                    'attribute2_name', [v1, v2], ....}
+
+        Returns:
+          doc_vector: document vector ignoring excluded tokens
+        """
+
+        vectors = None
+
+        # Count the tokens that have vectors
+        vector_count = 0
+
+        for token in self:
+
+            # Get the vector of the token if one exists and is token is not excluded
+            exclude_token = all([getattr(token._, key) not in excluded_tokens[key] for key in excluded_tokens.keys() if hasattr(token._, key)])
+
+            if token.has_vector and exclude_token:
+                # Increment the vector counter
+                vector_count += 1
+
+                # Cumulate token's vector by summing them
+                vectors = token.vector if vectors is None else vectors + token.vector
+
+        # If no tokens with vectors were found, just get the default vector(zeros)
+        if vector_count == 0:
+            doc_vector = self.vocab.vectors.default_vector
+        else:
+            # Create the final Doc vector
+            doc_vector = vectors / vector_count
+
+
+
+        return doc_vector
+
     def get_encrypted_vector(
-        self, *workers: BaseWorker, crypto_provider: BaseWorker = None, requires_grad: bool = True
+        self,
+        *workers: BaseWorker,
+        crypto_provider: BaseWorker = None,
+        requires_grad: bool = True,
+        excluded_tokens: Dict = None
     ):
         """Get the mean of the vectors of each Token in this documents.
 

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -177,7 +177,7 @@ class Doc(AbstractObject):
 
         for token in self:
 
-            # Get the vector of the token if one exists and is token is not excluded
+            # Get the vector of the token if one exists and if token is not excluded
             exclude_token = all([getattr(token._, key) not in excluded_tokens[key] for key in excluded_tokens.keys() if hasattr(token._, key)])
 
             if token.has_vector and exclude_token:

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -181,8 +181,13 @@ class Doc(AbstractObject):
 
             include_token = True
             if excluded_tokens is not None:
-                include_token = all([getattr(token._, key) not in excluded_tokens[key] for key in excluded_tokens.keys() if hasattr(token._, key)])
-
+                include_token = all(
+                    [
+                        getattr(token._, key) not in excluded_tokens[key]
+                        for key in excluded_tokens.keys()
+                        if hasattr(token._, key)
+                    ]
+                )
 
             if token.has_vector and include_token:
                 # Increment the vector counter
@@ -204,7 +209,7 @@ class Doc(AbstractObject):
         *workers: BaseWorker,
         crypto_provider: BaseWorker = None,
         requires_grad: bool = True,
-        excluded_tokens: Dict = None
+        excluded_tokens: Dict = None,
     ):
         """Get the mean of the vectors of each Token in this documents.
 

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -4,11 +4,12 @@ import torch
 
 hook = syft.TorchHook(torch)
 
-from typing import Dict
+
 from syft.generic.object import AbstractObject
 from syft.workers.base import BaseWorker
 
 from typing import List
+from typing import Dict
 from typing import Set
 from typing import Union
 from .underscore import Underscore
@@ -168,6 +169,9 @@ class Doc(AbstractObject):
             doc_vector: document vector ignoring excluded tokens
         """
 
+        # enforcing that the excluded_tokens dict indexes, by the name of the attributes, sets of values.
+        excluded_tokens = {attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens}
+
         # if the excluded_token dict in None all token are included
         if excluded_tokens is None:
             return self.vector
@@ -231,7 +235,7 @@ class Doc(AbstractObject):
         ), "You need at least two workers in order to encrypt the vector with SMPC"
 
         # Storing the average of vectors of each in-vocabulary token's vectors
-        doc_vector = self.get_vector(excluded_tokens)
+        doc_vector = self.get_vector(excluded_tokens=excluded_tokens)
 
         # Create a Syft/Torch tensor
         doc_vector = torch.Tensor(doc_vector)

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -170,7 +170,9 @@ class Doc(AbstractObject):
         """
 
         # enforcing that the excluded_tokens dict indexes, by the name of the attributes, sets of values.
-        excluded_tokens = {attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens}
+        excluded_tokens = {
+            attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens
+        }
 
         # if the excluded_token dict in None all token are included
         if excluded_tokens is None:

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -164,7 +164,7 @@ class Doc(AbstractObject):
             excluded_tokens (Dict): A dictionary used to ignore tokens of the document based on values of their attributes,
                                     the keys are the attributes names and they index lists values.
                                         Example: {'attribute1_name' : [value1, value2],
-                                                    'attribute2_name', [v1, v2], ....}
+                                                    'attribute2_name': [v1, v2], ....}
 
         Returns:
           doc_vector: document vector ignoring excluded tokens
@@ -178,9 +178,13 @@ class Doc(AbstractObject):
         for token in self:
 
             # Get the vector of the token if one exists and if token is not excluded
-            exclude_token = all([getattr(token._, key) not in excluded_tokens[key] for key in excluded_tokens.keys() if hasattr(token._, key)])
 
-            if token.has_vector and exclude_token:
+            include_token = True
+            if excluded_tokens is not None:
+                include_token = all([getattr(token._, key) not in excluded_tokens[key] for key in excluded_tokens.keys() if hasattr(token._, key)])
+
+
+            if token.has_vector and include_token:
                 # Increment the vector counter
                 vector_count += 1
 
@@ -193,9 +197,6 @@ class Doc(AbstractObject):
         else:
             # Create the final Doc vector
             doc_vector = vectors / vector_count
-
-
-
         return doc_vector
 
     def get_encrypted_vector(

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -173,7 +173,7 @@ class Doc(AbstractObject):
         if excluded_tokens is None:
             return self.vector
 
-        # enforcing that the excluded_tokens dict indexes, by the name of the attributes, sets of values.
+        # enforcing that the values of the excluded_tokens dict are sets, not lists.
         excluded_tokens = {
             attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens
         }

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -169,14 +169,14 @@ class Doc(AbstractObject):
             doc_vector: document vector ignoring excluded tokens
         """
 
+        # if the excluded_token dict in None all token are included
+        if excluded_tokens is None:
+            return self.vector
+
         # enforcing that the excluded_tokens dict indexes, by the name of the attributes, sets of values.
         excluded_tokens = {
             attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens
         }
-
-        # if the excluded_token dict in None all token are included
-        if excluded_tokens is None:
-            return self.vector
 
         vectors = None
 

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -112,6 +112,7 @@ def test_update_custom_attr_doc():
 
 def test_exclude_tokens_on_attr_values_doc():
     """Test that the get_vector method ignores tokens based on the excluded_tokens dict"""
+
     doc = nlp("Joey doesnt ever share food ")
     doc_excluding_tokens = nlp("Joey doesnt share food")
 
@@ -119,8 +120,13 @@ def test_exclude_tokens_on_attr_values_doc():
     token = doc[2]
     token.set_attribute(name="attribute1_name", value="value1")
 
-    # initialize excluded excluded_tokens dict
-    excluded_tokens = {"attribute1_name": ["value1", "value2"], "attribute2_name": ["v1", "v2"]}
+    # initialize the excluded_tokens dict
+    excluded_tokens = {"attribute1_name": {"value1", "value2"}, "attribute2_name": {"v1", "v2"}}
 
+    # checks if get_vector returns the same vector for doc and the doc with the word to exclude already missing,
+    # all() is needed because equals for numpy arrays returns an array of booleans.
     assert all(doc.get_vector(excluded_tokens) == doc_excluding_tokens.get_vector())
+
+    # checks if get_vector without excluded_tokens returns a different vector for doc
+    # and doc with the word to exclude already missing.
     assert any(doc.get_vector() != doc_excluding_tokens.get_vector())

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -108,3 +108,22 @@ def test_update_custom_attr_doc():
 
     # now check the updated attribute
     assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "new_tag"
+
+def test_exclude_tokens_on_attr_values_doc():
+    """Test that the get_vector method ignores tokens based on the excluded_tokens dict"""
+    doc = nlp("Joey doesnt ever share food ")
+    doc_excluding_tokens = nlp("Joey doesnt share food")
+
+    #add custom_attr to the last token, the word ever
+    token = doc[2]
+    token.set_attribute(name="attribute1_name", value="value1")
+
+    #initialize excluded excluded_tokens dict
+    excluded_tokens = {'attribute1_name' : ['value1', 'value2'], 'attribute2_name': ['v1', 'v2']}
+
+
+
+    assert (all(doc.get_vector(excluded_tokens) == doc_excluding_tokens.get_vector()))
+    assert (any(doc.get_vector() != doc_excluding_tokens.get_vector()))
+
+

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -109,21 +109,18 @@ def test_update_custom_attr_doc():
     # now check the updated attribute
     assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "new_tag"
 
+
 def test_exclude_tokens_on_attr_values_doc():
     """Test that the get_vector method ignores tokens based on the excluded_tokens dict"""
     doc = nlp("Joey doesnt ever share food ")
     doc_excluding_tokens = nlp("Joey doesnt share food")
 
-    #add custom_attr to the last token, the word ever
+    # add custom_attr to the last token, the word ever
     token = doc[2]
     token.set_attribute(name="attribute1_name", value="value1")
 
-    #initialize excluded excluded_tokens dict
-    excluded_tokens = {'attribute1_name' : ['value1', 'value2'], 'attribute2_name': ['v1', 'v2']}
+    # initialize excluded excluded_tokens dict
+    excluded_tokens = {"attribute1_name": ["value1", "value2"], "attribute2_name": ["v1", "v2"]}
 
-
-
-    assert (all(doc.get_vector(excluded_tokens) == doc_excluding_tokens.get_vector()))
-    assert (any(doc.get_vector() != doc_excluding_tokens.get_vector()))
-
-
+    assert all(doc.get_vector(excluded_tokens) == doc_excluding_tokens.get_vector())
+    assert any(doc.get_vector() != doc_excluding_tokens.get_vector())


### PR DESCRIPTION
# Pull Request Template

## Description

Add the get_vector method to ignore tokens when getting the average vector of the doc.

If your pull request closes a GitHub issue, then set its number below.

Fixes #43 

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I added a test that verifies that the get_vector result with the excluded tokens is equal to the result of the method run on a doc with the token to exclude removed
- [ ] Test B

## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [x] I have added tests for my changes