### PR TITLE
Added similarity of documents and tokens

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -156,17 +156,19 @@ class Doc(AbstractObject):
         return doc_vector
 
     @property
-    def vector_norm(self):
-        """
-        Get L2 norm of document vector
+    def vector_norm(self) -> torch.FloatTensor:
+        """Get the L2 norm of the document vector
 
         Returns:
-            Tensor(float): L2 norm of the document vector
+            A torch tensor representing the L2 norm of the document vector
         """
+        
         vector = torch.tensor(self.vector)
-        total = (vector ** 2).sum()
+        
+        norm = (vector ** 2).sum()
+        norm = torch.sqrt(norm)
 
-        return torch.sqrt(total)
+        return norm
 
     def similarity(self, other):
         """Make a cosine similarity between two docs' vectors.

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -170,8 +170,8 @@ class Doc(AbstractObject):
 
         return norm
 
-    def similarity(self, other):
-        """Make a cosine similarity between two docs' vectors.
+    def similarity(self, other: "Doc") -> torch.Tensor:
+        """Compute the cosine similarity between two Doc vectors.
         
         Args:
             other (Doc): The Doc to compare with.
@@ -180,14 +180,16 @@ class Doc(AbstractObject):
             Tensor: A cosine similarity score. Higher is more similar.
         """
 
+        # Make sure both vectors have non-zero norms
         assert (
             self.vector_norm.item() != 0.0 and other.vector_norm.item() != 0.0
-        ), "one or both of the tokens is invalid"
+        ), "One of the provided vectors has a zero norm!"
 
-        return torch.dot(torch.tensor(self.vector), torch.tensor(other.vector)) / (
-            self.vector_norm * other.vector_norm
-        )
+        # Compute similarity
+        sim = torch.dot(torch.tensor(self.vector), torch.tensor(other.vector))
+        sim /= self.vector_norm * other.vector_norm
 
+        return  sim
     def get_vector(self, excluded_tokens: Dict[str, Set[object]] = None):
         """Get document vector as an average of in-vocabulary token's vectors,
         excluding token according to the excluded_tokens dictionary.

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -154,6 +154,37 @@ class Doc(AbstractObject):
 
         return doc_vector
 
+    @property
+    def vector_norm(self):
+        """
+        Get L2 norm of document vector
+
+        Returns:
+            Tensor(float): L2 norm of the document vector
+        """
+        vector = torch.tensor(self.vector)
+        total = (vector ** 2).sum()
+
+        return torch.sqrt(total)
+
+    def similarity(self, other):
+        """Make a cosine similarity between two docs' vectors.
+        
+        Args:
+            other (Doc): The Doc to compare with.
+        
+        Returns:
+            Tensor: A cosine similarity score. Higher is more similar.
+        """
+
+        assert (
+            self.vector_norm.item() != 0.0 and other.vector_norm.item() != 0.0
+        ), "one of the token is invalid"
+
+        return torch.dot(torch.tensor(self.vector), torch.tensor(other.vector)) / (
+            self.vector_norm * other.vector_norm
+        )
+
     def get_encrypted_vector(
         self, *workers: BaseWorker, crypto_provider: BaseWorker = None, requires_grad: bool = True
     ):

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -179,7 +179,7 @@ class Doc(AbstractObject):
 
         assert (
             self.vector_norm.item() != 0.0 and other.vector_norm.item() != 0.0
-        ), "one of the token is invalid"
+        ), "one or both of the tokens is invalid"
 
         return torch.dot(torch.tensor(self.vector), torch.tensor(other.vector)) / (
             self.vector_norm * other.vector_norm

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -162,9 +162,9 @@ class Doc(AbstractObject):
         Returns:
             A torch tensor representing the L2 norm of the document vector
         """
-        
+
         vector = torch.tensor(self.vector)
-        
+
         norm = (vector ** 2).sum()
         norm = torch.sqrt(norm)
 
@@ -189,7 +189,8 @@ class Doc(AbstractObject):
         sim = torch.dot(torch.tensor(self.vector), torch.tensor(other.vector))
         sim /= self.vector_norm * other.vector_norm
 
-        return  sim
+        return sim
+
     def get_vector(self, excluded_tokens: Dict[str, Set[object]] = None):
         """Get document vector as an average of in-vocabulary token's vectors,
         excluding token according to the excluded_tokens dictionary.

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -55,6 +55,37 @@ class Token:
         """Get the token vector"""
         return self.doc.vocab.vectors[self.text]
 
+    @property
+    def vector_norm(self):
+        """The L2 norm of the token's vector representation.
+
+        Returns: 
+            Tensor: The L2 norm of the vector representation.
+        """
+
+        vector = torch.tensor(self.vector)
+        total = (vector ** 2).sum()
+
+        return torch.sqrt(total)
+
+    def similarity(self, other):
+        """Make a cosine similarity between tokens' vectors.
+        
+        Args:
+            other (Token): The Token to compare with.
+        
+        Returns:
+            Tensor: A cosine similarity score. Higher is more similar.
+        """
+
+        assert (
+            self.vector_norm.item() != 0.0 and other.vector_norm.item() != 0.0
+        ), "one of the token is invalid"
+
+        return torch.dot(torch.tensor(self.vector), torch.tensor(other.vector)) / (
+            self.vector_norm * other.vector_norm
+        )
+
     def get_encrypted_vector(self, *workers, crypto_provider=None, requires_grad=True):
         """Get the mean of the vectors of each Token in this documents.
 

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -54,18 +54,21 @@ class Token:
         return self.doc.vocab.vectors[self.text]
 
     @property
-    def vector_norm(self):
+    def vector_norm(self) -> torch.Tensor:
         """The L2 norm of the token's vector representation.
 
         Returns: 
             Tensor: The L2 norm of the vector representation.
         """
-
+        
+        # Convert the vector from a numpy array to a Tensor
         vector = torch.tensor(self.vector)
-        total = (vector ** 2).sum()
+        
+        # Compute the norm
+        norm = (vector ** 2).sum()
+        norm = torch.sqrt(norm)
 
-        return torch.sqrt(total)
-
+        return norm
     def similarity(self, other):
         """Make a cosine similarity between tokens' vectors.
         

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -70,7 +70,7 @@ class Token:
 
         return norm
     def similarity(self, other):
-        """Make a cosine similarity between tokens' vectors.
+        """Compute the cosine similarity between tokens' vectors.
         
         Args:
             other (Token): The Token to compare with.
@@ -78,14 +78,17 @@ class Token:
         Returns:
             Tensor: A cosine similarity score. Higher is more similar.
         """
-
+        
+        # Make sure both vectors have non-zero norms
         assert (
             self.vector_norm.item() != 0.0 and other.vector_norm.item() != 0.0
-        ), "one of the token is invalid"
+        ), "One of the provided tokens has a zero norm."
 
-        return torch.dot(torch.tensor(self.vector), torch.tensor(other.vector)) / (
-            self.vector_norm * other.vector_norm
-        )
+        # Compute similarity
+        sim = torch.dot(torch.tensor(self.vector), torch.tensor(other.vector))
+        sim /= self.vector_norm * other.vector_norm
+
+        return  sim
 
     def get_encrypted_vector(self, *workers, crypto_provider=None, requires_grad=True):
         """Get the mean of the vectors of each Token in this documents.

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -60,15 +60,16 @@ class Token:
         Returns: 
             Tensor: The L2 norm of the vector representation.
         """
-        
+
         # Convert the vector from a numpy array to a Tensor
         vector = torch.tensor(self.vector)
-        
+
         # Compute the norm
         norm = (vector ** 2).sum()
         norm = torch.sqrt(norm)
 
         return norm
+
     def similarity(self, other):
         """Compute the cosine similarity between tokens' vectors.
         
@@ -78,7 +79,7 @@ class Token:
         Returns:
             Tensor: A cosine similarity score. Higher is more similar.
         """
-        
+
         # Make sure both vectors have non-zero norms
         assert (
             self.vector_norm.item() != 0.0 and other.vector_norm.item() != 0.0
@@ -88,7 +89,7 @@ class Token:
         sim = torch.dot(torch.tensor(self.vector), torch.tensor(other.vector))
         sim /= self.vector_norm * other.vector_norm
 
-        return  sim
+        return sim
 
     def get_encrypted_vector(self, *workers, crypto_provider=None, requires_grad=True):
         """Get the mean of the vectors of each Token in this documents.

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -108,3 +108,14 @@ def test_update_custom_attr_doc():
 
     # now check the updated attribute
     assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "new_tag"
+
+
+def test_doc_similarity():
+    """Test similarity between two Doc objects"""
+
+    doc1 = nlp("Joey doesnt share food")
+    doc2 = nlp("we were on a break")
+
+    assert doc1.similarity(doc2) == doc2.similarity(doc1)
+
+    assert -1 <= doc1.similarity(doc2).item() <= 1

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -109,7 +109,7 @@ def test_update_custom_attr_doc():
     # now check the updated attribute
     assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "new_tag"
 
- 
+
 def test_doc_similarity():
     """Test similarity between two Doc objects"""
 
@@ -120,7 +120,7 @@ def test_doc_similarity():
 
     assert -1 <= doc1.similarity(doc2).item() <= 1
 
- 
+
 def test_exclude_tokens_on_attr_values_doc():
     """Test that the get_vector method ignores tokens based on the excluded_tokens dict"""
 

--- a/tests/local_mode/test_token.py
+++ b/tests/local_mode/test_token.py
@@ -27,25 +27,14 @@ def test_non_valid_token_norm_is_zero():
     assert norm == 0.0
 
 
-def test_similarity_bw_valid_tokens():
-    """Test that the similarity of valid tokens is not zero"""
+def test_similarity_tokens():
+    """Test that the similarity of valid tokens"""
     doc = nlp("hello banana")
     token1 = doc[0]
     token2 = doc[1]
 
-    sim = token1.similarity(token2).item()
+    # check commutativity of similarity
+    assert token1.similarity(token2) == token2.similarity(token1)
 
-    # check that similarity is not zero for two valid unequal token
-    assert sim != 0.0
-
-
-def test_similarity_bw_same_valid_tokens():
-    """Test that the similarity of valid equal tokens is one"""
-    doc = nlp("banana banana")
-    token1 = doc[0]
-    token2 = doc[1]
-
-    sim = token1.similarity(token2).item()
-
-    # check that norm is one for equal valid tokens
-    assert sim == 1.0
+    # check if similarity is in valid range
+    assert -1.0 < token1.similarity(token2).item() < 1.0

--- a/tests/local_mode/test_token.py
+++ b/tests/local_mode/test_token.py
@@ -1,0 +1,51 @@
+import syft as sy
+import torch
+import syfertext
+import numpy as np
+
+hook = sy.TorchHook(torch)
+me = hook.local_worker
+
+nlp = syfertext.load("en_core_web_lg", owner=me)
+
+
+def test_valid_token_norm_is_not_zero():
+    """Test that the norm of a valid token is not zero"""
+    doc = nlp("banana")
+    norm = doc[0].vector_norm
+
+    # check that norm is not zero for valid token
+    assert norm != 0.0
+
+
+def test_non_valid_token_norm_is_zero():
+    """Test that the norm of a invalid token is zero"""
+    doc = nlp("not-valid-token")
+    norm = doc[0].vector_norm
+
+    # check that norm is zero for invalid token
+    assert norm == 0.0
+
+
+def test_similarity_bw_valid_tokens():
+    """Test that the similarity of valid tokens is not zero"""
+    doc = nlp("hello banana")
+    token1 = doc[0]
+    token2 = doc[1]
+
+    sim = token1.similarity(token2)
+
+    # check that similarity is not zero for two valid unequal token
+    assert sim != 0.0
+
+
+def test_similarity_bw_same_valid_tokens():
+    """Test that the similarity of valid equal tokens is one"""
+    doc = nlp("banana banana")
+    token1 = doc[0]
+    token2 = doc[1]
+
+    sim = token1.similarity(token2)
+
+    # check that norm is one for equal valid tokens
+    assert sim == 1.0

--- a/tests/local_mode/test_token.py
+++ b/tests/local_mode/test_token.py
@@ -11,6 +11,7 @@ nlp = syfertext.load("en_core_web_lg", owner=me)
 
 def test_valid_token_norm_is_not_zero():
     """Test that the norm of a valid token is not zero"""
+    
     doc = nlp("banana")
     norm = doc[0].vector_norm.item()
 
@@ -18,9 +19,10 @@ def test_valid_token_norm_is_not_zero():
     assert norm != 0.0
 
 
-def test_non_valid_token_norm_is_zero():
-    """Test that the norm of a invalid token is zero"""
-    doc = nlp("not-valid-token")
+def test_oov_token_norm_is_zero():
+    """Test that the norm of an out-of-vocab oken is zero"""
+    
+    doc = nlp("notvalidtoken")
     norm = doc[0].vector_norm.item()
 
     # check that norm is zero for invalid token
@@ -29,6 +31,7 @@ def test_non_valid_token_norm_is_zero():
 
 def test_similarity_tokens():
     """Test that the similarity of valid tokens"""
+    
     doc = nlp("hello banana")
     token1 = doc[0]
     token2 = doc[1]

--- a/tests/local_mode/test_token.py
+++ b/tests/local_mode/test_token.py
@@ -37,4 +37,4 @@ def test_similarity_tokens():
     assert token1.similarity(token2) == token2.similarity(token1)
 
     # check if similarity is in valid range
-    assert -1.0 < token1.similarity(token2).item() < 1.0
+    assert -1.0 <= token1.similarity(token2).item() <= 1.0

--- a/tests/local_mode/test_token.py
+++ b/tests/local_mode/test_token.py
@@ -11,7 +11,7 @@ nlp = syfertext.load("en_core_web_lg", owner=me)
 
 def test_valid_token_norm_is_not_zero():
     """Test that the norm of a valid token is not zero"""
-    
+
     doc = nlp("banana")
     norm = doc[0].vector_norm.item()
 
@@ -21,7 +21,7 @@ def test_valid_token_norm_is_not_zero():
 
 def test_oov_token_norm_is_zero():
     """Test that the norm of an out-of-vocab oken is zero"""
-    
+
     doc = nlp("notvalidtoken")
     norm = doc[0].vector_norm.item()
 
@@ -31,7 +31,7 @@ def test_oov_token_norm_is_zero():
 
 def test_similarity_tokens():
     """Test that the similarity of valid tokens"""
-    
+
     doc = nlp("hello banana")
     token1 = doc[0]
     token2 = doc[1]

--- a/tests/local_mode/test_token.py
+++ b/tests/local_mode/test_token.py
@@ -12,7 +12,7 @@ nlp = syfertext.load("en_core_web_lg", owner=me)
 def test_valid_token_norm_is_not_zero():
     """Test that the norm of a valid token is not zero"""
     doc = nlp("banana")
-    norm = doc[0].vector_norm
+    norm = doc[0].vector_norm.item()
 
     # check that norm is not zero for valid token
     assert norm != 0.0
@@ -21,7 +21,7 @@ def test_valid_token_norm_is_not_zero():
 def test_non_valid_token_norm_is_zero():
     """Test that the norm of a invalid token is zero"""
     doc = nlp("not-valid-token")
-    norm = doc[0].vector_norm
+    norm = doc[0].vector_norm.item()
 
     # check that norm is zero for invalid token
     assert norm == 0.0
@@ -33,7 +33,7 @@ def test_similarity_bw_valid_tokens():
     token1 = doc[0]
     token2 = doc[1]
 
-    sim = token1.similarity(token2)
+    sim = token1.similarity(token2).item()
 
     # check that similarity is not zero for two valid unequal token
     assert sim != 0.0
@@ -45,7 +45,7 @@ def test_similarity_bw_same_valid_tokens():
     token1 = doc[0]
     token2 = doc[1]
 
-    sim = token1.similarity(token2)
+    sim = token1.similarity(token2).item()
 
     # check that norm is one for equal valid tokens
     assert sim == 1.0


### PR DESCRIPTION
## Description

I just thought it would be a nice addition to include similarity between tokens.
I have added similarity between docs as well on the basis of averaged token vectors.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

```python
doc1 = nlp("hello banana")
doc2 = nlp("artic monkeys")
token1 = doc1[0]
token2 = doc1[1]

token1.vector_norm 
# L2 norm

token1.similarity(token2)
# cosine similarity

doc1.vector_norm
# L2 norm of doc

doc1.similarity(doc2)
# cosine similarity
```


## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [x] I have added tests for my changes