### PR TITLE
Model download -> tmp path -> data path

### DIFF
--- a/syfertext/utils.py
+++ b/syfertext/utils.py
@@ -4,6 +4,8 @@ import logging
 import urllib.request as request
 from tqdm import tqdm
 from pathlib import Path
+import tempfile
+import shutil
 
 # Files to download for each language model
 # TODO: Downloading language models should be handled
@@ -38,9 +40,6 @@ def get_lang_model(model_name: str):
          with. it should be revisited later.
     """
 
-    # Path to this file
-    file_path = os.path.dirname(os.path.realpath(__file__))
-
     # Path to the folder containing language models
     data_path = os.path.join(str(Path.home()), "SyferText")
 
@@ -52,36 +51,29 @@ def get_lang_model(model_name: str):
 
         os.mkdir(data_path)
 
-        # a flag signified that the model show be downloaded
-        download_model = True
-
     # If the data folder does not contain the language model
     # folder, download the language model
     if model_name not in os.listdir(data_path):
 
         download_model = True
 
-        # full path of the model folder to create
-        model_path = os.path.join(data_path, model_name)
-
-        # Create the model folder
-        os.mkdir(model_path)
-
     if download_model:
 
-        # download model files into the specified path
-        _download_model(model_name, model_path)
+        # download model files into a temporary path
+        tmp_model_path = _download_model(model_name)
+
+        # move temporary model directory to the models folder
+        shutil.move(tmp_model_path, data_path)
 
 
-def _download_model(model_name: str, model_path: str):
+def _download_model(model_name: str):
     """Download the language model files through HTTP.
 
     Args:
         model_name (str): The name of the language model.
-        model_path (str): The path to the folder in which model files are downloaded.
     """
 
-    # Intialize the totla size of the language model
+    # Intialize the total size of the language model
     model_size = 0
 
     # chunk size during download (in bytes)
@@ -97,13 +89,22 @@ def _download_model(model_name: str, model_path: str):
     # Initialize the progress bar object of tqdm
     prog_bar = tqdm(total=model_size, unit="B", unit_scale=True, desc=model_name)
 
+    # get the temporary directory path
+    tmp_data_path = tempfile.gettempdir()
+
+    # create the temporary model path
+    tmp_model_path = os.path.join(tmp_data_path, model_name)
+
+    if not os.path.exists(tmp_model_path):
+        os.mkdir(tmp_model_path)
+
     # start download
     for file_url in lang_model_files[model_name]:
 
         # Create the file path
         file_name = os.path.basename(file_url).split("?")[0]
 
-        file_path = os.path.join(model_path, file_name)
+        file_path = os.path.join(tmp_model_path, file_name)
 
         # Create the request object
         req = request.urlopen(file_url)
@@ -123,8 +124,7 @@ def _download_model(model_name: str, model_path: str):
                     prog_bar.update(chunk_size)
 
                 else:
-
                     # Downloading the file finished
                     break
-
     prog_bar.close()
+    return tmp_model_path

--- a/tests/local_mode/test_language.py
+++ b/tests/local_mode/test_language.py
@@ -1,6 +1,8 @@
+import os
 import syft as sy
 import torch
 import syfertext
+from pathlib import Path
 import numpy as np
 
 hook = sy.TorchHook(torch)
@@ -11,17 +13,37 @@ nlp = syfertext.load("en_core_web_lg", owner=me)
 
 def test_vector_valid_token_is_not_zero():
     """Test that the vector of a valid token is not all zeros"""
+
     doc = nlp("banana")
     actual = doc[0].vector
     zeros = np.zeros(actual.shape)
+
     # check that at least one cell in actual vector is not zero
     assert (actual != zeros).any() == True
 
 
 def test_vector_non_valid_token_is_zero():
     """Test that the vector of non valid token is all zeros"""
+
     doc = nlp("non-valid-token")
     actual = doc[0].vector
     zeros = np.zeros(actual.shape)
+
     # check that all cells in actual vector are zeros
     assert (actual == zeros).all() == True
+
+
+def test_language_model_download_path():
+    """Tests that downloading a model returns a valid & correct path"""
+
+    # Retrieve the model's path from its vocabulary
+    model_path = nlp.vocab.model_path
+
+    # Set the expected path for the `en_core_web_lg` model
+    expected_model_path = os.path.join(str(Path.home()), "SyferText", "en_core_web_lg")
+
+    # check if the model path exists
+    assert os.path.exists(model_path)
+
+    # check if the model path is the same as the expected path
+    assert model_path == expected_model_path


### PR DESCRIPTION

## Description

Every time the downloading of a model fails (for various reasons) we have to remove the `~/SyferText` data folder because `SyferText` tries to retrieve non-existing files in our next attempt to get the model. I ran into this issue multiple times because of the relatively slow connection on my local setup.

I solved the issue by first downloading the model into a temporary path, then only after successfully downloading the files they are moved to `~/SyferText`.

Fixes #51 

## Type of change

Please mark the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

We can reproduce the problem by interrupting the download process.
I tested the new edits using the notebook's cell:

```Python
nlp = syfertext.load('en_core_web_lg', owner = me)

type(nlp), nlp.owner
```

On the following cases:
- Without a data path
- With a data path but by interrupting the download
- After downloading the model

## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [ ] I have added tests for my changes