### PR TITLE
doc owner fix

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -19,7 +19,6 @@ class Doc(AbstractObject):
     def __init__(
         self,
         vocab,
-        text,
         id: int = None,
         owner: BaseWorker = None,
         tags: List[str] = None,

--- a/syfertext/pipeline/subpipeline.py
+++ b/syfertext/pipeline/subpipeline.py
@@ -133,6 +133,9 @@ class SubPipeline(AbstractObject):
         # Execute the first pipe in the subpipeline
         doc = self.subpipeline[0](input)
 
+        # set the owner of the doc object as the current worker
+        doc.owner = self.owner
+
         # Execute the  rest of pipes in the subpipeline
         for pipe in self.subpipeline[1:]:
             doc = pipe(doc)

--- a/syfertext/tokenizer.py
+++ b/syfertext/tokenizer.py
@@ -138,7 +138,7 @@ class Tokenizer(AbstractObject):
         # I do not assign the Doc here any owner, this will
         # be done by the SupPipeline object that operates
         # this tokenizer.
-        doc = Doc(self.vocab, text)
+        doc = Doc(self.vocab)
 
         # The number of characters in the text
         text_size = len(text)

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -1,6 +1,8 @@
 import syft as sy
 import torch
 import syfertext
+from syft.generic.string import String
+from syfertext.pointers.doc_pointer import DocPointer
 
 import numpy as np
 
@@ -130,3 +132,32 @@ def test_exclude_tokens_on_attr_values_doc():
     # checks if get_vector without excluded_tokens returns a different vector for doc
     # and doc with the word to exclude already missing.
     assert any(doc.get_vector() != doc_excluding_tokens.get_vector())
+
+
+def test_ownership_doc_local():
+    """Tests that the doc object created on the local worker is owned by the local worker itself"""
+
+    # create a local doc object
+    doc = nlp("we were on a break")
+
+    # test the doc owner is the local worker
+    assert doc.owner == me
+
+
+def test_ownership_doc_remote():
+    """Tests that the doc object pointed by doc pointer is owned by remote worker"""
+
+    # create a remote worker
+    bob = sy.VirtualWorker(hook=hook, id="bob")
+
+    # get a String Pointer
+    text_ptr = String("we were on a break").send(bob)
+
+    # create a doc pointer
+    doc = nlp(text_ptr)
+
+    # check owner of the doc pointer
+    assert doc.owner == me
+
+    # check owner of doc object pointed by the `doc` DocPointer
+    assert bob._objects[doc.id_at_location].owner == bob


### PR DESCRIPTION
Fixes #73 
We can explicitly assign the `doc.owner = self.owner` when we know that the doc is on a remote worker
@AlanAboudib your review would be helpful