### PR TITLE
Some cleaning

### DIFF
--- a/syfertext/pipeline/subpipeline.py
+++ b/syfertext/pipeline/subpipeline.py
@@ -155,19 +155,7 @@ class SubPipeline(AbstractObject):
             return doc.id
 
         # Otherwise, the `doc_or_id` variable is a Doc
-        # object, if it has no owner yet, assign it the
-        # same owner as the this object.
-        # It is not yet clear if a Doc object actually
-        # needs an owner. Are we going to ever need to
-        # send a Doc object to another worker? If yes
-        # then an owner is needed. Let's give it an
-        # owner for now.
-        # A Doc owner will usually be None when returned
-        # from the tokenizer, which is not itself aware
-        # of which worker it is in.
-        if doc.owner is None:
-            doc.owner = self.owner
-
+        # object
         return doc
 
     @staticmethod


### PR DESCRIPTION

## Description

Remove owner assignment to the `Doc` object at the end of the `__call__` method of the `SubPipeline` class. The owner is assigned correctly in #74 



## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [ ] I have added tests for my changes