### PR TITLE
Added get_attribute to Token and Doc

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -68,13 +68,13 @@ class Doc(AbstractObject):
         setattr(self._, name, value)
 
     def has_attribute(self, name: str) -> bool:
-        """Returns `True` if the Underscore object `self._` has an attribute `name`. otherwise returns `False` 
+        """Returns `True` if the Underscore object `self._` has an attribute `name`. otherwise returns `False`
 
         Args:
             name (str): name of the custom attribute.
-        
+
         Returns:
-            attr_exists (bool): `True` if `self._.name` exists, otherwise `False`  
+            attr_exists (bool): `True` if `self._.name` exists, otherwise `False`
         """
 
         # `True` if `self._` has attribute `name`, `False` otherwise
@@ -90,16 +90,28 @@ class Doc(AbstractObject):
         """
 
         # Before removing the attribute, check if it exists
-        assert self.has_attribute(name), "Document does not have the attribute {}".format(name)
+        assert self.has_attribute(name), f"Document does not have the attribute {name}"
 
         delattr(self._, name)
+
+    def get_attribute(self, name: str):
+        """Returns value of custom attribute with the name `name` if it is present, else raises `AttributeError`.
+
+        Args:
+            name (str): name of the custom attribute.
+
+        Returns:
+            value (obj): value of the custom attribute with name `name`.
+        """
+
+        return getattr(self._, name)
 
     def __getitem__(self, key: Union[int, slice]) -> Union[Token, Span, int]:
         """Returns a Token object at position `key` or Span object using slice.
 
 
         Args:
-            key (int or slice): The index of the token within the Doc, 
+            key (int or slice): The index of the token within the Doc,
                 or the slice of the Doc to return as a Span object.
         Returns:
             Token or Span or id of the Span object.
@@ -258,7 +270,7 @@ class Doc(AbstractObject):
                 Example: {'attribute1_name' : {value1, value2}, 'attribute2_name': {v1, v2}, ....}
 
         Returns:
-            token_vectors: The Numpy array of shape - (No.of tokens, size of vector) 
+            token_vectors: The Numpy array of shape - (No.of tokens, size of vector)
                 containing all the vectors.
         """
 
@@ -343,16 +355,16 @@ class Doc(AbstractObject):
 
         Args:
             workers (sequence of BaseWorker): A sequence of remote workers from .
-            crypto_provider (BaseWorker): A remote worker responsible for providing cryptography 
+            crypto_provider (BaseWorker): A remote worker responsible for providing cryptography
                 (SMPC encryption) functionalities.
             requires_grad (bool): A boolean flag indicating whether gradients are required or not.
             excluded_tokens (Dict): A dictionary used to ignore tokens of the document based on values
-                of their attributes, the keys are the attributes names and they index, for efficiency, 
+                of their attributes, the keys are the attributes names and they index, for efficiency,
                 sets of values.
                 Example: {'attribute1_name' : {value1, value2}, 'attribute2_name': {v1, v2}, ....}
 
         Returns:
-            Tensor: A SMPC-encrypted tensor representing the array of all vectors in this document, 
+            Tensor: A SMPC-encrypted tensor representing the array of all vectors in this document,
                 ingonoring the excluded token.
         """
 

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -44,11 +44,6 @@ class Token(AbstractObject):
         # Whether this token has a vector or not
         self.has_vector = self.doc.vocab.vectors.has_vector(self.orth_)
 
-    def __len__(self):
-        """Returns the length of the token's text."""
-
-        return len(self.text)
-
     def set_attribute(self, name: str, value: object):
         """Creates a custom attribute with the name `name` and
            value `value` in the Underscore object `self._`

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from .utils import hash_string
 
 import syft as sy
@@ -50,12 +49,6 @@ class Token(AbstractObject):
 
         return len(self.text)
 
-    def __str__(self):
-
-        # The call to `str()` in the following is to account for the case
-        # when text is of type String or StringPointer (which are Syft string types)
-        return self.orth_
-
     def set_attribute(self, name: str, value: object):
         """Creates a custom attribute with the name `name` and
            value `value` in the Underscore object `self._`
@@ -77,9 +70,9 @@ class Token(AbstractObject):
 
         Args:
             name (str): name of the custom attribute.
-        
+
         Returns:
-            attr_exists (bool): `True` if `self._.name` exists, otherwise `False`  
+            attr_exists (bool): `True` if `self._.name` exists, otherwise `False`
         """
 
         # `True` if `self._` has attribute `name`, `False` otherwise
@@ -95,15 +88,28 @@ class Token(AbstractObject):
         """
 
         # Before removing the attribute, check if it exist
-        assert self.has_attribute(name), "token does not have the attribute {}".format(name)
+        assert self.has_attribute(name), f"token does not have the attribute {name}"
 
         delattr(self._, name)
 
-    def nbor(self, offset=1) -> Token:
+    def get_attribute(self, name: str):
+        """Returns value of custom attribute with the name `name` if it is present, else raises `AttributeError`.
+
+        Args:
+            name (str): name of the custom attribute.
+
+        Returns:
+            value (obj): value of the custom attribute with name `name`.
+        """
+
+        return getattr(self._, name)
+
+    def nbor(self, offset=1):
         """Gets the neighbouring token at `self.position + offset` if it exists
+
         Args:
             offset (int): the relative position of the neighbour with respect to current token.
-        
+
         Returns:
             neighbor (Token): the neighbor of the current token with a relative position `offset`.
         """
@@ -111,11 +117,16 @@ class Token(AbstractObject):
         # The neighbor's index should be within the document's range of indices
         assert (
             0 <= self.position + offset < len(self.doc)
-        ), "Token at position {} does not exist".format(self.position + offset)
+        ), f"Token at position {self.position + offset} does not exist"
 
         neighbor = self.doc[self.position + offset]
 
         return neighbor
+
+    def __str__(self):
+        # The call to `str()` in the following is to account for the case
+        # when text is of type String or StringPointer (which are Syft string types)
+        return self.orth_
 
     @property
     def text(self):
@@ -141,7 +152,7 @@ class Token(AbstractObject):
             return self.orth_
 
     def __repr__(self):
-        return "Token[{}]".format(self.orth_)
+        return f"Token[{self.orth_}]"
 
     @property
     def vector(self):

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -113,7 +113,7 @@ def test_check_custom_attr():
 
 
 def test_remove_custom_attr():
-    """Test the deletion of a custom Doc attribute"""
+    """Test the deletion of a custom Doc and Token attribute"""
 
     doc = nlp("Joey doesnt share food")
     token = doc[0]
@@ -127,25 +127,48 @@ def test_remove_custom_attr():
     token.remove_attribute(name="token_tag")
 
     # Verify they do were removed
-    assert (not doc.has_attribute("doc_tag")) and (not token.has_attribute("token_tag"))
+    assert not doc.has_attribute("doc_tag")
+    assert not token.has_attribute("token_tag")
+
+
+def test_get_custom_attr():
+    """Test getting the value of custom attribute from Doc and Token."""
+
+    doc = nlp("Joey doesnt share food")
+    token = doc[0]
+
+    token_value, doc_value = "token_value", "doc_value"
+
+    # add custom attributes
+    doc.set_attribute(name="doc_tag", value=doc_value)
+    token.set_attribute(name="token_tag", value=token_value)
+
+    # Assert values are the values we set
+    assert doc.get_attribute("doc_tag") == doc_value
+    assert token.get_attribute("token_tag") == token_value
 
 
 def test_update_custom_attr_doc():
-    """Test updating custom attribute of Doc objects"""
+    """Test updating custom attribute of Doc and Token object"""
 
     doc = nlp("Joey doesnt share food")
+    token = doc[0]
 
-    # add new custom attribute
-    doc.set_attribute(name="my_custom_tag", value="tag")
+    # add new custom attributes
+    doc.set_attribute(name="doc_tag", value="doc_value")
+    token.set_attribute(name="token_tag", value="token_value")
 
-    # check custom attribute has been added
-    assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "tag"
+    # check custom attributes values are set
+    assert doc.get_attribute("doc_tag") == "doc_value"
+    assert token.get_attribute("token_tag") == "token_value"
 
-    # now update the attribute
-    doc.set_attribute(name="my_custom_tag", value="new_tag")
+    # now update the attributes
+    doc.set_attribute(name="doc_tag", value="new_doc_value")
+    token.set_attribute(name="token_tag", value="new_token_value")
 
     # now check the updated attribute
-    assert hasattr(doc._, "my_custom_tag") and doc._.my_custom_tag == "new_tag"
+    assert doc.get_attribute("doc_tag") == "new_doc_value"
+    assert token.get_attribute("token_tag") == "new_token_value"
 
 
 def test_exclude_tokens_on_attr_values_doc():


### PR DESCRIPTION
Extending the work in #80 , added get_attribute() for Token and Doc to get the values of custom attributes.

```python

doc.set_attribute("doc_tag", "doc_value")
token.set_attribute("doc_tag", "token_value")

doc.get_attribute("doc_tag")  # doc_value
token.get_attribute("token_tag") # token_value
```
- Removed duplicate  `__len__` in token.
- Also fixed import error: `from __future__ import annotations` which is supported starting from Python 3.7

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tests added to tests/local/test_doc.py

## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
* [x] I have added tests for my changes