### PR TITLE
[WIP] add Quick UMLS entity extraction as a pipeline method

### DIFF
--- a/syfertext/pipeline/medical/quick_umls.py
+++ b/syfertext/pipeline/medical/quick_umls.py
@@ -1,0 +1,23 @@
+from syfertext.doc import Doc
+from syfertext.token import Token
+from typing import Union
+
+from quickumls_simstring import simstring
+
+class QuickUMLS:
+    """ Extracts medical entities using
+    approximation matching. Also does UMLS linking by
+    returning respective CUIs of matched entities.
+
+    Inspired from :
+        QuickUMLS : https://github.com/Georgetown-IR-Lab/QuickUMLS
+        For more info, refer to the paper : http://medir2016.imag.fr/data/MEDIR_2016_paper_16.pdf
+    """
+
+    def __init__(self):
+        pass
+
+    def __call__(self, doc: Doc):
+        pass
+
+    


### PR DESCRIPTION
## Introduction
QuickUMLS is a Fast, Unsupervised Approach for Medical Concept Extraction. It extracts medical entities using approximation matching. Also does UMLS linking by returning respective CUIs of matched entities.

It is similar or better than the current state of the art cTAKES or MetaMap and is also significantly faster (2 to 135 times).

For more info, refer to the paper : http://medir2016.imag.fr/data/MEDIR_2016_paper_16.pdf

## Usage
```python
from pipelines.medical import quickUMLS

quick_umls = quickUMLS()
nlp.add_pipe(quick_umls,'quickumls')

doc = nlp(text)
doc._cuis
```

I will be working on this with @codeboy5. If anyone else want to contribute to this PR, feel free to ping me here. 😄 