### PR TITLE
[WIP] add Quick UMLS entity extraction as a pipeline method

### DIFF
--- a/syfertext/__init__.py
+++ b/syfertext/__init__.py
@@ -3,6 +3,7 @@ from .tokenizer import Tokenizer
 from .pointers.doc_pointer import DocPointer
 from .pipeline import SubPipeline
 from .pipeline import SimpleTagger
+from .pipeline.medical import QuickUMLS
 from . import utils
 
 import syft
@@ -71,6 +72,7 @@ def register_to_serde(class_type: type):
 Tokenizer.proto_id = register_to_serde(Tokenizer)
 SubPipeline.proto_id = register_to_serde(SubPipeline)
 SimpleTagger.proto_id = register_to_serde(SimpleTagger)
+QuickUMLS.proto_id = register_to_serde(QuickUMLS)
 
 # Set the default owners of some classes
 SubPipeline.owner = hook.local_worker

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -51,6 +51,11 @@ class Doc(AbstractObject):
         # using the `self.set_attribute` method
         self._ = Underscore()
 
+        # Empty list to store named entities
+        # This list will contain Spans of named entities
+        # To access type of entity use Span._.type ?? TODO
+        self.ents = list()
+
     def set_attribute(self, name: str, value: object):
         """Creates a custom attribute with the name `name` and
            value `value` in the Underscore object `self._`

--- a/syfertext/pipeline/medical/__init__.py
+++ b/syfertext/pipeline/medical/__init__.py
@@ -1,0 +1,1 @@
+from .quick_umls import QuickUMLS

--- a/syfertext/pipeline/medical/quick_umls.py
+++ b/syfertext/pipeline/medical/quick_umls.py
@@ -136,14 +136,16 @@ class QuickUMLS:
         for match in matches:
             
             # TODO : maybe first add cuis in StringStore
-            cuis = []
+            cuis = set()
             for each_match in match:
-                cuis.append(each_match['cui'])
+                cuis.add(each_match['cui'])
+                
+            cui_list = list(cuis)
             
             entity = Span(doc, match[0]['start'], match[0]['end'])
 
             # Set cuis in custom attr
-            entity.set_attribute('cuis', cuis)
+            entity.set_attribute('cuis', cui_list)
             entity.set_attribute('ent_type','medical term')
 
             doc.ents.append(entity)

--- a/syfertext/pipeline/medical/quick_umls.py
+++ b/syfertext/pipeline/medical/quick_umls.py
@@ -13,11 +13,43 @@ class QuickUMLS:
         QuickUMLS : https://github.com/Georgetown-IR-Lab/QuickUMLS
         For more info, refer to the paper : http://medir2016.imag.fr/data/MEDIR_2016_paper_16.pdf
     """
+    # TODO : add accepted sem types option as well
+    def __init__(
+        self, 
+        quick_umls_database = './umls_data_lower',
+        threshold = 0.85, 
+        overlapping_criteria = 'score',
+        window = 5,
+        similarity_name = 'jaccard', 
+        keep_uppercase = False
+    ):
+        """ 
+        Instantiate QuickUMLS object. This is the main interface through 
+        which text can be processed.
+        Args:
+            quick_umls_database (str): Path to UMLS dictionary
+            
+            overlapping_criteria (str, optional):
+                    One of "score" or "length". Choose how results are ranked.
+                    Choose "score" for best matching score first or "length" for longest match first.. Defaults to 'score'.
 
-    def __init__(self):
+            threshold (float, optional): Minimum similarity between strings. Defaults to 0.7.
+
+            window (int, optional): Maximum amount of tokens to consider for matching. Defaults to 5.
+
+            similarity_name (str, optional): One of "dice", "jaccard", "cosine", or "overlap".
+                    Similarity measure to be used. Defaults to 'jaccard'.
+
+            keep_uppercase (bool, optional): By default QuickUMLS converts all
+                    uppercase strings to lowercase. This option disables that
+                    functionality, which makes QuickUMLS useful for
+                    distinguishing acronyms from normal words. 
+                    
+                    For this the database to be used must be `./umls_data`
+                    Defaults to False.
+        """
         pass
+
 
     def __call__(self, doc: Doc):
         pass
-
-    

--- a/syfertext/pipeline/medical/quick_umls.py
+++ b/syfertext/pipeline/medical/quick_umls.py
@@ -2,8 +2,6 @@ from syfertext.doc import Doc
 from syfertext.token import Token
 from typing import Union
 
-from quickumls_simstring import simstring
-
 class QuickUMLS:
     """ Extracts medical entities using
     approximation matching. Also does UMLS linking by

--- a/syfertext/pipeline/medical/quick_umls.py
+++ b/syfertext/pipeline/medical/quick_umls.py
@@ -1,0 +1,23 @@
+from syfertext.doc import Doc
+from syfertext.token import Token
+from typing import Union
+
+from quickumls_simstring import simstring
+
+class QuickUMLS:
+    """ Extracts medical entities using
+    approximation matching. Also does UMLS linking by
+    returning respective CUIs of matched entities.
+
+    Inspired from :
+        QuickUMLS : https://github.com/Georgetown-IR-Lab/QuickUMLS
+        For more info, refer to the paper : http://medir2016.imag.fr/data/MEDIR_2016_paper_16.pdf
+    """
+
+    def __init__(self):
+        pass
+
+    def __call__(self, doc: Doc):
+        pass
+
+    

--- a/syfertext/pipeline/medical/quick_umls.py
+++ b/syfertext/pipeline/medical/quick_umls.py
@@ -1,4 +1,5 @@
 from syfertext.doc import Doc
+from syfertext.span import Span
 from syfertext.token import Token
 from typing import Union
 
@@ -45,7 +46,7 @@ class QuickUMLS:
                     functionality, which makes QuickUMLS useful for
                     distinguishing acronyms from normal words. 
                     
-                    For this the database to be used must be `./umls_data`
+                    For this, the database to be used must be `./umls_data`
                     Defaults to False.
         """
         pass
@@ -61,6 +62,23 @@ class QuickUMLS:
         # make spans  ??
         # maybe in doc.ents ?? or in doc.medical_ents ??
         # definitely put in doc.cuis
+
+        for match in matches:
+            
+            # TODO : maybe first add cuis in StringStore
+            cuis = []
+            for each_match in match:
+                cuis.append(each_match['cui'])
+            
+            entity = Span(doc, match[0]['start'], match[0]['end'])
+
+            # Set cuis in custom attr
+            entity.set_attribute('cuis', cuis)
+            entity.set_attribute('ent_type','medical term')
+
+            doc.ents.append(entity)
+
+            # to access definition use, quickUMLS.kb[cui] to extract definitions    
 
         return doc
 

--- a/syfertext/pipeline/medical/quick_umls.py
+++ b/syfertext/pipeline/medical/quick_umls.py
@@ -49,7 +49,33 @@ class QuickUMLS:
                     For this, the database to be used must be `./umls_data`
                     Defaults to False.
         """
-        pass
+
+        valid_criteria = {'length', 'score'}
+        err_msg = (
+            '"{}" is not a valid overlapping_criteria. Choose '
+            'between {}'.format(
+                overlapping_criteria, ', '.join(valid_criteria)
+            )
+        )
+        assert overlapping_criteria in valid_criteria, err_msg
+        self.overlapping_criteria = overlapping_criteria
+
+        valid_similarities = {'dice', 'jaccard', 'cosine', 'overlap'}
+        err_msg = ('"{}" is not a valid similarity name. Choose between '
+                   '{}'.format(similarity_name, ', '.join(valid_similarities)))
+        assert not(valid_similarities in valid_similarities), err_msg
+        self.similarity_name = similarity_name
+
+        simstring_fp = quick_umls_database
+        # CUI Types.
+
+        self.window = window
+        self.ngram_length = 3
+        self.threshold = threshold
+        self.min_match_length = 3
+        self.keep_uppercase = keep_uppercase
+        self.string_to_cui = {}
+
 
 
     def __call__(self, doc: Doc):
@@ -183,6 +209,21 @@ class QuickUMLS:
                 intervals.append(match_interval)
 
         return final_matches_subset 
+    
+    def _make_ngrams(self, text):
+    # make window sized token grams
+    tokens = text.split(' ')
+    doc_window_list = []
+    for i in range(len(tokens)):
+        curr = tokens[i]
+        for j in range(i+1,min(i + self.window + 1, len(tokens))):
+            doc_window_list.append((i,j,curr))
+            curr += " "
+            curr += tokens[j]
+        doc_window_list.append((i,min(i + self.window + 1, len(tokens)),curr))
+    return doc_window_list
+
+
 
     # NOTE : we are not currently using the heuristcs introduced in the paper (Soldaini and Goharian, 2016).
     # Also make better doc strings

--- a/syfertext/span.py
+++ b/syfertext/span.py
@@ -129,6 +129,21 @@ class Span(AbstractObject):
 
             return span
 
+    @property
+    def text_with_ws(self):
+        """The text content of the span with a trailing whitespace character if
+        the last token has one.
+        """
+        return "".join([token.text_with_ws for token in self])
+    
+    @property
+    def text(self):
+        """returns The original verbatim text of the span."""
+        text = self.text_with_ws
+        if self[-1].is_space:
+            text = text[:-1]
+        return text
+
     def __len__(self):
         """Return the number of tokens in the Span."""
         return self.end - self.start

--- a/syfertext/utils.py
+++ b/syfertext/utils.py
@@ -10,6 +10,9 @@ from typing import Tuple
 import tempfile
 import shutil
 
+from quickumls_simstring import simstring
+import unicodedata
+
 
 def hash_string(string: str) -> int:
     """Create a hash for a given string. 
@@ -114,3 +117,22 @@ def compile_infix_regex(entries: Tuple) -> Pattern:
     return re.compile(expression)
     prog_bar.close()
     return tmp_model_path
+
+def safe_unicode(s):
+    return u'{}'.format(unicodedata.normalize('NFKD', s))
+
+class SimstringDBReader(object):
+    """Used to get candidates for medical extraction. Uses CPMerge
+    Alogorithm to find approximate matches.
+
+    Inspired from : https://github.com/Georgetown-IR-Lab/QuickUMLS/blob/master/quickumls/toolbox.py
+    For more info refer to paper : <CPmerge paper>
+    """
+    def __init__(self, database_umls : str, similarity_name : str, threshold : float):
+        self.db = simstring.reader(database_umls)
+        self.db.measure = getattr(simstring, similarity_name)
+        self.db.threshold = threshold
+
+    def get(self, term):
+        term = safe_unicode(term)
+        return self.db.retrieve(term)

--- a/syfertext/utils.py
+++ b/syfertext/utils.py
@@ -130,8 +130,8 @@ class SimstringDBReader(object):
     Inspired from : https://github.com/Georgetown-IR-Lab/QuickUMLS/blob/master/quickumls/toolbox.py
     For more info refer to paper : <CPmerge paper>
     """
-    def __init__(self, database_umls : str, similarity_name : str, threshold : float):
-        self.db = simstring.reader(database_umls)
+    def __init__(self, database : str, similarity_name : str, threshold : float):
+        self.db = simstring.reader(database)
         self.db.measure = getattr(simstring, similarity_name)
         self.db.threshold = threshold
 
@@ -142,7 +142,7 @@ class SimstringDBReader(object):
 def make_ngrams(s, n):
     # s = u'{t}{s}{t}'.format(s=safe_unicode(s), t=('$' * (n - 1)))
     n = len(s) if len(s) < n else n
-    return (s[i:i + n] for i in xrange(len(s) - n + 1))
+    return (s[i:i + n] for i in range(len(s) - n + 1))
 
 
 def get_similarity(x, y, n, similarity_name):


### PR DESCRIPTION
## Intro
QuickUMLS is a Fast, Unsupervised Approach for Medical Concept Extraction. It extracts medical entities using approximation matching. Also does UMLS linking by returning respective CUIs of matched entities.

It is similar or better than the current state of the art cTAKES or MetaMap and is also significantly faster (2 to 135 times).

For more info, refer to the paper : http://medir2016.imag.fr/data/MEDIR_2016_paper_16.pdf

## Usage
```python
from pipelines.medical import quickUMLS

quick_umls = quickUMLS()
nlp.add_pipe(quick_umls,'quickumls')

doc = nlp(text)
doc._cuis
```
@codeboy5 will be collaborating with me on this one.