### PR TITLE
Added _get_valid_tokens() to Doc and Span

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -394,7 +394,7 @@ class Doc(AbstractObject):
                         if token.has_attribute(key)
                     ]
                 )
-                
+
                 if include_token:
                     yield token
         else:

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -13,6 +13,7 @@ from typing import List
 from typing import Dict
 from typing import Set
 from typing import Union
+from typing import Generator
 from .underscore import Underscore
 from .span import Span
 from .pointers.span_pointer import SpanPointer
@@ -250,7 +251,7 @@ class Doc(AbstractObject):
         if vector_count == 0:
             doc_vector = self.vocab.vectors.default_vector
         else:
-            # Take average of the vectors
+            # The Doc vector, which is the average of all vectors
             doc_vector = vectors / vector_count
         return doc_vector
 
@@ -362,17 +363,17 @@ class Doc(AbstractObject):
 
         return token_vectors
 
-    def _get_valid_tokens(self, excluded_tokens):
+    def _get_valid_tokens(self, excluded_tokens: Dict[str, Set[object]] = None) -> Generator[Token]:
         """Handy function to handle the logic of excluding tokens while performing operations on Doc.
 
         Args:
             excluded_tokens (Dict): A dictionary used to ignore tokens of the document based on values
                 of their attributes.
-        Returns:
+        Yields:
             A generator with valid tokens, i.e. tokens which are `not` to be excluded.
         """
 
-        if excluded_tokens is not None:
+        if excluded_tokens:
             # Enforcing that the values of the excluded_tokens dict are sets, not lists.
             excluded_tokens = {
                 attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -167,18 +167,18 @@ class Doc(AbstractObject):
             yield self[i]
 
     @property
-    def vector(self):
-        """Get doc vector as an average of in-vocabulary token's vectors
-
-        Returns:
-            span_vector: doc vector.
-        """
-        return self.get_vector()
-
-    @property
     def text(self):
         """Returns the text present in the doc with whitespaces"""
         return "".join(token.text_with_ws for token in self)
+
+    @property
+    def vector(self):
+        """Get document vector as an average of in-vocabulary token's vectors
+
+        Returns:
+            doc_vector: doc vector
+        """
+        return self.get_vector()
 
     @property
     def vector_norm(self) -> torch.FloatTensor:

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -363,7 +363,9 @@ class Doc(AbstractObject):
 
         return token_vectors
 
-    def _get_valid_tokens(self, excluded_tokens: Dict[str, Set[object]] = None) -> Generator[Token]:
+    def _get_valid_tokens(
+        self, excluded_tokens: Dict[str, Set[object]] = None
+    ) -> Generator[Token, None, None]:
         """Handy function to handle the logic of excluding tokens while performing operations on Doc.
 
         Args:

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -371,6 +371,7 @@ class Doc(AbstractObject):
         Args:
             excluded_tokens (Dict): A dictionary used to ignore tokens of the document based on values
                 of their attributes.
+                Example: {'attribute1_name' : {value1, value2}, 'attribute2_name': {v1, v2}, ....}
         Yields:
             A generator with valid tokens, i.e. tokens which are `not` to be excluded.
         """
@@ -381,8 +382,11 @@ class Doc(AbstractObject):
                 attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens
             }
 
+            # Iterate over all tokens in doc
             for token in self:
 
+                # Check if token can be included by comparing its attribute values
+                # to those in excluded_tokens dictionary.
                 include_token = all(
                     [
                         token.get_attribute(key) not in excluded_tokens[key]

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -394,6 +394,7 @@ class Doc(AbstractObject):
                         if token.has_attribute(key)
                     ]
                 )
+                
                 if include_token:
                     yield token
         else:

--- a/syfertext/pointers/doc_pointer.py
+++ b/syfertext/pointers/doc_pointer.py
@@ -47,6 +47,32 @@ class DocPointer(ObjectPointer):
             description=description,
         )
 
+    def __len__(self):
+
+        # Send the command
+        length = self.owner.send_command(
+            recipient=self.location, cmd_name="__len__", target=self, args_=tuple(), kwargs_={}
+        )
+
+        return length
+
+    def __getitem__(self, item: Union[slice, int]) -> SpanPointer:
+
+        # if item is int, so we are trying to access to token
+        assert isinstance(
+            item, slice
+        ), "You are not authorised to access a `Token` from a `DocPointer`"
+
+        # Send the command
+        obj_id = self.owner.send_command(
+            recipient=self.location, cmd_name="__getitem__", target=self, args_=(item,), kwargs_={}
+        )
+
+        # we create a SpanPointer from the obj_id
+        span = SpanPointer(location=self.location, id_at_location=obj_id, owner=self.owner)
+
+        return span
+
     def get_encrypted_vector(
         self,
         *workers: BaseWorker,
@@ -93,23 +119,6 @@ class DocPointer(ObjectPointer):
         doc_vector = doc_vector.get()
 
         return doc_vector
-
-    def __getitem__(self, item: Union[slice, int]) -> SpanPointer:
-
-        # if item is int, so we are trying to access to token
-        assert isinstance(
-            item, slice
-        ), "You are not authorised to access a `Token` from a `DocPointer`"
-
-        # Send the command
-        obj_id = self.owner.send_command(
-            recipient=self.location, cmd_name="__getitem__", target=self, args_=(item,), kwargs_={}
-        )
-
-        # we create a SpanPointer from the obj_id
-        span = SpanPointer(location=self.location, id_at_location=obj_id, owner=self.owner)
-
-        return span
 
     def get_encrypted_token_vectors(
         self,
@@ -160,12 +169,3 @@ class DocPointer(ObjectPointer):
         token_vectors = token_vectors.get()
 
         return token_vectors
-
-    def __len__(self):
-
-        # Send the command
-        length = self.owner.send_command(
-            recipient=self.location, cmd_name="__len__", target=self, args_=tuple(), kwargs_={},
-        )
-
-        return length

--- a/syfertext/pointers/doc_pointer.py
+++ b/syfertext/pointers/doc_pointer.py
@@ -61,7 +61,7 @@ class DocPointer(ObjectPointer):
         # if item is int, so we are trying to access to token
         assert isinstance(
             item, slice
-        ), "You are not authorised to access a `Token` from a `DocPointer`"
+        ), "You are not authorized to access a `Token` from a `DocPointer`"
 
         # Send the command
         obj_id = self.owner.send_command(

--- a/syfertext/span.py
+++ b/syfertext/span.py
@@ -188,7 +188,9 @@ class Span(AbstractObject):
 
         return span_vector
 
-    def _get_valid_tokens(self, excluded_tokens: Dict[str, Set[object]] = None) -> Generator[Token]:
+    def _get_valid_tokens(
+        self, excluded_tokens: Dict[str, Set[object]] = None
+    ) -> Generator[Token, None, None]:
         """Handy function to handle the logic of excluding tokens while performing operations on Doc.
 
         Args:

--- a/syfertext/span.py
+++ b/syfertext/span.py
@@ -206,8 +206,11 @@ class Span(AbstractObject):
                 attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens
             }
 
+            # Iterate over all tokens in doc
             for token in self:
 
+                # Check if token can be included by comparing its attribute values
+                # to those in excluded_tokens dictionary.
                 include_token = all(
                     [
                         token.get_attribute(key) not in excluded_tokens[key]

--- a/syfertext/span.py
+++ b/syfertext/span.py
@@ -11,6 +11,7 @@ from typing import List
 from typing import Dict
 from typing import Set
 from typing import Union
+from typing import Generator
 
 from .underscore import Underscore
 from .utils import normalize_slice
@@ -182,22 +183,22 @@ class Span(AbstractObject):
         if vector_count == 0:
             span_vector = self.doc.vocab.vectors.default_vector
         else:
-            # Create the final span vector
+            # The Doc vector, which is the average of all vectors
             span_vector = vectors / vector_count
 
         return span_vector
 
-    def _get_valid_tokens(self, excluded_tokens):
+    def _get_valid_tokens(self, excluded_tokens: Dict[str, Set[object]] = None) -> Generator[Token]:
         """Handy function to handle the logic of excluding tokens while performing operations on Doc.
 
         Args:
             excluded_tokens (Dict): A dictionary used to ignore tokens of the document based on values
                 of their attributes.
-        Returns:
+        Yields:
             A generator with valid tokens, i.e. tokens which are `not` to be excluded.
         """
 
-        if excluded_tokens is not None:
+        if excluded_tokens:
             # Enforcing that the values of the excluded_tokens dict are sets, not lists.
             excluded_tokens = {
                 attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens

--- a/syfertext/span.py
+++ b/syfertext/span.py
@@ -20,17 +20,15 @@ class Span(AbstractObject):
     """A slice from a Doc object.
     """
 
-    def __init__(
-        self, doc: "Doc", start: int, end: int, id: int = None, owner: BaseWorker = None,
-    ):
+    def __init__(self, doc: "Doc", start: int, end: int, id: int = None, owner: BaseWorker = None):
         """Create a `Span` object from the slice `doc[start : end]`.
 
         Args:
             doc (Doc): The parent document.
             start (int): The index of the first token of the span.
             end (int): The index of the first token after the span.
-        
-        Returns (Span): 
+
+        Returns (Span):
             The newly constructed object.
 
         """
@@ -75,7 +73,7 @@ class Span(AbstractObject):
         setattr(self._, name, value)
 
     def __getitem__(self, key: Union[int, slice]):
-        """Returns a Token object at position `key` or returns Span using slice `key` or the 
+        """Returns a Token object at position `key` or returns Span using slice `key` or the
         id of the Token object or id of the Span object at remote location.
 
         Args:
@@ -148,32 +146,7 @@ class Span(AbstractObject):
         Returns:
             span_vector: span vector
         """
-
-        # Accumulate the vectors here
-        vectors = None
-
-        # Count the tokens that have vectors
-        vector_count = 0
-
-        for token in self:
-
-            # Get the vector of the token if one exists
-            if token.has_vector:
-
-                # Increment the vector counter
-                vector_count += 1
-
-                # Cumulate token's vector by summing them
-                vectors = token.vector if vectors is None else vectors + token.vector
-
-        # If no tokens with vectors were found, just get the default vector(zeros)
-        if vector_count == 0:
-            span_vector = self.doc.vocab.vectors.default_vector
-        else:
-            # Create the final span vector
-            span_vector = vectors / vector_count
-
-        return span_vector
+        return self.get_vector()
 
     def get_vector(self, excluded_tokens: Dict[str, Set[object]] = None):
         """Get Span vector as an average of in-vocabulary token's vectors,
@@ -188,39 +161,21 @@ class Span(AbstractObject):
             span_vector: Span vector ignoring excluded tokens
         """
 
-        # If the excluded_token dict in None then all token are included
-        if excluded_tokens is None:
-            return self.vector
-
-        # Enforcing that the values of the excluded_tokens dict are sets, not lists.
-        excluded_tokens = {
-            attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens
-        }
+        # Get the valid tokens which are to be included
+        valid_tokens = self._get_valid_tokens(excluded_tokens)
 
         vectors = None
 
         # Count the tokens that have vectors
         vector_count = 0
 
-        for token in self:
+        for token in valid_tokens:
 
-            # Get the vector of the token if one exists and if token is not excluded
-
-            include_token = True
-
-            include_token = all(
-                [
-                    getattr(token._, key) not in excluded_tokens[key]
-                    for key in excluded_tokens.keys()
-                    if hasattr(token._, key)
-                ]
-            )
-
-            if token.has_vector and include_token:
+            if token.has_vector:
                 # Increment the vector counter
                 vector_count += 1
 
-                # Cumulate token's vector by summing them
+                # Accumulate token's vector by summing them
                 vectors = token.vector if vectors is None else vectors + token.vector
 
         # If no tokens with vectors were found, just get the default vector(zeros)
@@ -231,6 +186,38 @@ class Span(AbstractObject):
             span_vector = vectors / vector_count
 
         return span_vector
+
+    def _get_valid_tokens(self, excluded_tokens):
+        """Handy function to handle the logic of excluding tokens while performing operations on Doc.
+
+        Args:
+            excluded_tokens (Dict): A dictionary used to ignore tokens of the document based on values
+                of their attributes.
+        Returns:
+            A generator with valid tokens, i.e. tokens which are `not` to be excluded.
+        """
+
+        if excluded_tokens is not None:
+            # Enforcing that the values of the excluded_tokens dict are sets, not lists.
+            excluded_tokens = {
+                attribute: set(excluded_tokens[attribute]) for attribute in excluded_tokens
+            }
+
+            for token in self:
+
+                include_token = all(
+                    [
+                        token.get_attribute(key) not in excluded_tokens[key]
+                        for key in excluded_tokens.keys()
+                        if token.has_attribute(key)
+                    ]
+                )
+                if include_token:
+                    yield token
+        else:
+            # All tokens are included
+            for token in self:
+                yield token
 
     def as_doc(self):
         """Create a `Doc` object with a copy of the `Span`'s tokens.

--- a/syfertext/span.py
+++ b/syfertext/span.py
@@ -218,6 +218,7 @@ class Span(AbstractObject):
                         if token.has_attribute(key)
                     ]
                 )
+
                 if include_token:
                     yield token
         else:


### PR DESCRIPTION
## Description

Added `_get_valid_tokens(excluded_tokens)`, a central place to handle all logic related to excluding tokens for `Doc` and `Span`. `_get_valid_tokens` returns a **generator** which yields valid tokens (tokens which are not to be excluded).

- Makes the code more readable, and much fewer lines.
- Gives us a central location to handle excluding tokens, and can be extended to include other methods of excluding tokens.

## Type of Change
Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [x] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
Existing tests.

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have added tests for my changes
