### PR TITLE
Removed __len__ from DocPointer and SpanPointer 

### DIFF
--- a/syfertext/pointers/doc_pointer.py
+++ b/syfertext/pointers/doc_pointer.py
@@ -45,15 +45,6 @@ class DocPointer(ObjectPointer):
             description=description,
         )
 
-    def __len__(self):
-
-        # Send the command
-        length = self.owner.send_command(
-            recipient=self.location, cmd_name="__len__", target=self, args_=tuple(), kwargs_={}
-        )
-
-        return length
-
     def __getitem__(self, item: Union[slice, int]) -> SpanPointer:
 
         # if item is int, so we are trying to access to token

--- a/syfertext/pointers/span_pointer.py
+++ b/syfertext/pointers/span_pointer.py
@@ -37,15 +37,6 @@ class SpanPointer(ObjectPointer):
             garbage_collect_data=True,  # Always True
         )
 
-    def __len__(self):
-
-        # Send the command
-        length = self.owner.send_command(
-            recipient=self.location, cmd_name="__len__", target=self, args_=tuple(), kwargs_={}
-        )
-
-        return length
-
     def __getitem__(self, item: Union[slice, int]):
 
         # if item is int, so we are trying to access to token


### PR DESCRIPTION
## Description
Removed the `__len__` method as it is a security breach.
This resolves #152 

## Affected Dependencies
None

## How has this been tested?


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
