### PR TITLE
Proto id generation update 

### DIFF
--- a/syfertext/pipeline/simple_tagger.py
+++ b/syfertext/pipeline/simple_tagger.py
@@ -218,8 +218,9 @@ class SimpleTagger(AbstractSendable):
         """
 
         # If a msgpack code is not already generated, then generate one
+        # the code is hash of class name
         if not hasattr(SimpleTagger, "proto_id"):
-            SimpleTagger.proto_id = msgpack_code_generator()
+            SimpleTagger.proto_id = msgpack_code_generator(SimpleTagger.__qualname__)
 
         code_dict = dict(code=SimpleTagger.proto_id)
 

--- a/syfertext/pipeline/subpipeline.py
+++ b/syfertext/pipeline/subpipeline.py
@@ -310,8 +310,9 @@ class SubPipeline(AbstractSendable):
         """
 
         # If a msgpack code is not already generated, then generate one
+        # the code is hash of class name
         if not hasattr(SubPipeline, "proto_id"):
-            SubPipeline.proto_id = msgpack_code_generator()
+            SubPipeline.proto_id = msgpack_code_generator(SubPipeline.__qualname__)
 
         code_dict = dict(code=SubPipeline.proto_id)
 

--- a/syfertext/tokenizer.py
+++ b/syfertext/tokenizer.py
@@ -595,7 +595,7 @@ class Tokenizer(AbstractSendable):
 
         model_name = pickle.dumps(tokenizer.vocab.model_name)
 
-        return model_name
+        return (model_name,)
 
     @staticmethod
     def detail(worker: BaseWorker, simple_obj: tuple):
@@ -610,8 +610,8 @@ class Tokenizer(AbstractSendable):
            tokenizer (Tokenizer) : a Tokenizer object
         """
 
-        # Get the tuple elements
-        model_name = simple_obj
+        # Get the model name from the tuple
+        model_name = simple_obj[0]
 
         # Unpickle
         model_name = pickle.loads(model_name)
@@ -640,8 +640,9 @@ class Tokenizer(AbstractSendable):
         """
 
         # If a msgpack code is not already generated, then generate one
+        # the code is hash of class name
         if not hasattr(Tokenizer, "proto_id"):
-            Tokenizer.proto_id = msgpack_code_generator()
+            Tokenizer.proto_id = msgpack_code_generator(Tokenizer.__qualname__)
 
         code_dict = dict(code=Tokenizer.proto_id)
 

--- a/syfertext/utils.py
+++ b/syfertext/utils.py
@@ -120,7 +120,7 @@ class MsgpackCodeGenerator:
     def __init__(self):
         pass
 
-    def __call__(self,cls_name) -> int:
+    def __call__(self, cls_name) -> int:
         """Generates and returns a unique msgpack code
 
         Returns:

--- a/syfertext/utils.py
+++ b/syfertext/utils.py
@@ -130,7 +130,7 @@ class MsgpackCodeGenerator:
         """
 
         # the code Msgpack is generated as the hash of class name
-        return hash_string(cls_name)
+        return hash_string(class_name)
 
 
 msgpack_code_generator = MsgpackCodeGenerator()

--- a/syfertext/utils.py
+++ b/syfertext/utils.py
@@ -120,8 +120,10 @@ class MsgpackCodeGenerator:
     def __init__(self):
         pass
 
-    def __call__(self, cls_name) -> int:
-        """Generates and returns a unique msgpack code
+    def __call__(self, class_name: str) -> int:
+        """Generates and returns a unique msgpack code.
+        Args:
+        class_name: The name of class for which the msgpack code is required.
 
         Returns:
             An integer to serve as a msgpack serialization code.

--- a/syfertext/utils.py
+++ b/syfertext/utils.py
@@ -118,19 +118,17 @@ def compile_infix_regex(entries: Tuple) -> Pattern:
 
 class MsgpackCodeGenerator:
     def __init__(self):
+        pass
 
-        self.code = 1999
-
-    def __call__(self) -> int:
+    def __call__(self,cls_name) -> int:
         """Generates and returns a unique msgpack code
 
         Returns:
             An integer to serve as a msgpack serialization code.
         """
 
-        self.code += 1
-
-        return self.code
+        # the code Msgpack is generated as the hash of class name
+        return hash_string(cls_name)
 
 
 msgpack_code_generator = MsgpackCodeGenerator()


### PR DESCRIPTION
## Description
The Proto id generated on different workers were different, so now the code is generated using the  hash of the class name

## Checklist
- [ x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ x] My changes are covered by tests
