### PR TITLE
fix: Adds missing parenthesis in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 
 ## SyferText
 
-SyferText is a library for privacy preserving Natural Language Processing in Python. It leverages PySyft to perform Federated Learning and Encrypted Computations (
-[Multi-Party Computation (MPC)](https://en.wikipedia.org/wiki/Secure_multi-party_computation) on text data. The two main usage scenarios of SyferText are:
+SyferText is a library for privacy preserving Natural Language Processing in Python. It leverages PySyft to perform Federated Learning and Encrypted Computations ([Multi-Party Computation (MPC)](https://en.wikipedia.org/wiki/Secure_multi-party_computation)) on text data. The two main usage scenarios of SyferText are:
 
 - :fire: **Secure plaintext pre-processing:** Enables pre-processing of  text located on a remote machine without breaking data privacy.
 - :rocket: **Secure pipeline deploy:** Starting from version 0.1.0, SyferText will be able to bundle the complete pipeline of pre-processing components and trained PySyft models and to securely deploy it to PyGrid.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,12 @@ setup(
     packages=find_packages(),
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    install_requires=["tqdm==4.36.1", "mmh3==2.5.1", "syft==0.2.8", "requests==2.22.0",],
+    install_requires=[
+        "tqdm==4.36.1",
+        "mmh3==2.5.1",
+        "syft==0.2.8",
+        "requests==2.22.0",
+    ],
     extras_require={
         "test": [
             "black>=19.10b0",

--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -303,7 +303,7 @@ class Doc(AbstractObject):
         Returns:
 
             Tensor: A tensor representing the SMPC-encrypted vector of this document.
-            
+
         """
 
         # You need at least two workers in order to encrypt the vector with SMPC

--- a/syfertext/language.py
+++ b/syfertext/language.py
@@ -15,8 +15,7 @@ from typing import List, Union, Tuple
 
 
 class BaseDefaults(object):
-    """A class that defines all the defaults of the Language class
-    """
+    """A class that defines all the defaults of the Language class"""
 
     @classmethod
     def create_vocab(cls, model_name: str) -> Vocab:
@@ -37,7 +36,7 @@ class BaseDefaults(object):
     def create_tokenizer(cls, vocab) -> Tokenizer:
         """Creates a Tokenizer object that will be used to create the Doc object, which is the
         main container for annotated tokens.
-        
+
         This Tokenizer object uses spaCy's tokenization rules. It takes prefixes,
         infixes, suffixes, tokenization exceptions into account.
         Of course, more features should be added later.
@@ -132,8 +131,7 @@ class Language(AbstractObject):
                 self.subpipeline_templates.append(subpipeline_template)
 
     def _reset_pipeline(self):
-        """Reset the `pipeline` class property.
-        """
+        """Reset the `pipeline` class property."""
 
         # Read the pipeline components from the template and aggregate them into
         # a list of subpipline templates.
@@ -159,7 +157,7 @@ class Language(AbstractObject):
         last: bool = True,
     ):
 
-        """Adds a pipe template to the pipeline template. 
+        """Adds a pipe template to the pipeline template.
 
         A pipe template is a dict of the form `{'remote': remote, 'name': name}`.
         Few main steps are carried out here:

--- a/syfertext/lexeme.py
+++ b/syfertext/lexeme.py
@@ -9,8 +9,7 @@ class LexemeMeta(object):
     """
 
     def __init__(self):
-        """Initializes a LexemeMeta object
-        """
+        """Initializes a LexemeMeta object"""
 
         self.flags = 0
         self.lang = 0
@@ -23,7 +22,7 @@ class LexemeMeta(object):
         self.suffix = 0
 
     def set_lexmeta_attr(self, attr_id: int, value: Union[int, bool]) -> None:
-        """ Sets all the attributes for given attribute id for LexemeMeta object 
+        """Sets all the attributes for given attribute id for LexemeMeta object
         according to the provided `value`.
 
         Args:
@@ -60,10 +59,10 @@ class LexemeMeta(object):
     # These 2 methods for checking and setting flags for
     # boolean attributes for Lexeme class are taken from Spacy.
     def check_flag(self, flag_id: int) -> bool:
-        """This method checks the value of flag corresponding to given flag_id. 
-        It check if bit at index corresponding to flag_id is 1 or 0. This method 
+        """This method checks the value of flag corresponding to given flag_id.
+        It check if bit at index corresponding to flag_id is 1 or 0. This method
         is inspired from Spacy.
-        
+
         Args:
             flag_id(int): The flag_id for corresponding attribute to check.
 
@@ -110,7 +109,7 @@ class LexemeMeta(object):
 
 class Lexeme:
     """Inspired by Spacy's Lexeme class. It is an entry in the vocabulary.
-    It holds various non-contextual attributes related to the corresponding string.  
+    It holds various non-contextual attributes related to the corresponding string.
     """
 
     def __init__(self, vocab: "Vocab", orth: int) -> None:
@@ -142,7 +141,7 @@ class Lexeme:
         return self.lex_meta.check_flag(flag_id)
 
     def set_flag(self, flag_id: int, value: bool) -> None:
-        """Set the sets the value of flag corresponding to flag_id to 1 or zero 
+        """Set the sets the value of flag corresponding to flag_id to 1 or zero
         according to provided attribute value. This method is inspired from Spacy.
 
         Args:
@@ -178,7 +177,7 @@ class Lexeme:
 
     @property
     def orth_(self):
-        """The original text of the lexeme (identical to `Lexeme.text`). 
+        """The original text of the lexeme (identical to `Lexeme.text`).
         This method is defined for consistency with the other attributes.
         """
         return self.vocab.store[self.lex_meta.orth]
@@ -198,7 +197,7 @@ class Lexeme:
     @property
     def flags(self):
         """Returns the flags Integer value.
-        One can get the value assigned to a specific flag_id by 
+        One can get the value assigned to a specific flag_id by
         looking at the bit corresponding to flag_id index of flags.
         """
 
@@ -265,8 +264,7 @@ class Lexeme:
 
     @property
     def is_stop(self):
-        """Whether the lexeme is a stop word.
-        """
+        """Whether the lexeme is a stop word."""
         return self.lex_meta.check_flag(Attributes.IS_STOP)
 
     @property
@@ -355,8 +353,7 @@ class Lexeme:
 
     @property
     def like_num(self) -> bool:
-        """Whether the lexeme resembles a number, e.g. "10.9", "10", etc.
-        """
+        """Whether the lexeme resembles a number, e.g. "10.9", "10", etc."""
 
         return self.lex_meta.check_flag(Attributes.LIKE_NUM)
 

--- a/syfertext/pipeline/simple_tagger.py
+++ b/syfertext/pipeline/simple_tagger.py
@@ -12,10 +12,10 @@ from typing import Dict
 
 class SimpleTagger(AbstractSendable):
     """This is a very simple token-level tagger. It enables to tag specified
-       tokens in a `Doc` object. By tagging a token, we mean setting a new
-       attribute to that token which holds the desired tag as its value.
-       The attribute becomes accessible then through the Underscore attribute
-       of the `Token` object.
+    tokens in a `Doc` object. By tagging a token, we mean setting a new
+    attribute to that token which holds the desired tag as its value.
+    The attribute becomes accessible then through the Underscore attribute
+    of the `Token` object.
     """
 
     def __init__(
@@ -34,13 +34,13 @@ class SimpleTagger(AbstractSendable):
                 this attribute will be accessible through the attribute
                 `._` of Token objects. Example `token_object._.<attribute>
             lookups (set, list or dict): If of type `list` of `set`, it should contain
-                the tokens that are to be searched for and tagged in the Doc 
+                the tokens that are to be searched for and tagged in the Doc
                 object's text. Example: ['the', 'myself', ...]
                 If of type `dict`, the keys should be the tokens texts to be
                 tagged, and values should hold a single tag for each such token.
                 Example: tagging stop words {'the': True, 'myself' : True}.
             tag (object, optional): If `lookups` is of type `list`, then this
-                will be the tag assigned to all matched tokens. It will be 
+                will be the tag assigned to all matched tokens. It will be
                 ignored if `lookups` if of type `dict`.
             default_tag: (object, optional): The default tag to be assigned
                 in case the token text maches no entry in `lookups`.
@@ -100,9 +100,9 @@ class SimpleTagger(AbstractSendable):
 
 
         Returns:
-            A transformed version  of `lookup` where all token texts are in 
+            A transformed version  of `lookup` where all token texts are in
             lower case.
- 
+
         """
 
         # Replace dict keys with lower-case versions
@@ -143,7 +143,7 @@ class SimpleTagger(AbstractSendable):
 
     @staticmethod
     def simplify(worker: BaseWorker, simple_tagger: "SimpleTagger"):
-        """Simplifies a SimpleTagger object. 
+        """Simplifies a SimpleTagger object.
 
         Args:
             worker (BaseWorker): The worker on which the
@@ -153,7 +153,7 @@ class SimpleTagger(AbstractSendable):
 
         Returns:
             (tuple): The simplified SimpleTagger object.
-        
+
         """
 
         # Simplify the object properties
@@ -167,7 +167,7 @@ class SimpleTagger(AbstractSendable):
 
     @staticmethod
     def detail(worker: BaseWorker, simple_obj: tuple):
-        """Takes a simplified SimpleTagger object, details it 
+        """Takes a simplified SimpleTagger object, details it
            and returns a SimpleTagger object.
 
         Args:

--- a/syfertext/span.py
+++ b/syfertext/span.py
@@ -18,8 +18,7 @@ from .utils import normalize_slice
 
 
 class Span(AbstractObject):
-    """A slice from a Doc object.
-    """
+    """A slice from a Doc object."""
 
     def __init__(self, doc: "Doc", start: int, end: int, id: int = None, owner: BaseWorker = None):
         """Create a `Span` object from the slice `doc[start : end]`.
@@ -59,11 +58,11 @@ class Span(AbstractObject):
 
     def set_attribute(self, name: str, value: object):
         """Creates a custom attribute with the name `name` and
-       value `value` in the Underscore object `self._`
+        value `value` in the Underscore object `self._`
 
-        Args:
-            name (str): name of the custom attribute.
-            value (object): value of the custom named attribute.
+         Args:
+             name (str): name of the custom attribute.
+             value (object): value of the custom named attribute.
         """
 
         # make sure there is no space in name as well prevent empty name

--- a/syfertext/string_store.py
+++ b/syfertext/string_store.py
@@ -3,8 +3,8 @@ from typing import Union
 
 
 class StringStore:
-    """ StringStore object acts as a lookup table.
-        It looks up strings by 64-bit hashes and vice-versa, looks up hashes by their corresponding strings.
+    """StringStore object acts as a lookup table.
+    It looks up strings by 64-bit hashes and vice-versa, looks up hashes by their corresponding strings.
     """
 
     def __init__(self, strings=None):

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -121,10 +121,10 @@ class Token(AbstractObject):
 
     def check_flag(self, flag_id: int) -> bool:
         """Checks the attribute corresponding to given `flag_id` flag value.
-        
+
         Args:
             flag_id(int): The attribute ID of the flag to check.
-    
+
         Returns:
             bool: Returns True if the value of flag corresponding to flag_id is 1 else False.
         """
@@ -175,7 +175,7 @@ class Token(AbstractObject):
     def vector_norm(self) -> torch.Tensor:
         """The L2 norm of the token's vector representation.
 
-        Returns: 
+        Returns:
             Tensor: The L2 norm of the vector representation.
         """
 
@@ -183,10 +183,10 @@ class Token(AbstractObject):
 
     def similarity(self, other):
         """Compute the cosine similarity between tokens vectors.
-        
+
         Args:
             other (Token): The Token to compare with.
-        
+
         Returns:
             Tensor: A cosine similarity score. Higher is more similar.
         """
@@ -260,7 +260,7 @@ class Token(AbstractObject):
     @property
     def shape(self):
         """Orth id of the token's shape, a transform of the
-            tokens's string, to show orthographic features (e.g. "Xxxx", "dd").
+        tokens's string, to show orthographic features (e.g. "Xxxx", "dd").
         """
         return self.lex_meta.shape
 
@@ -287,8 +287,8 @@ class Token(AbstractObject):
     @property
     def orth_(self):
         """Text content (identical to `Token.text`).
-            Exists mostly for consistency with the other
-            attributes.
+        Exists mostly for consistency with the other
+        attributes.
         """
         return self.doc.vocab.store[self.lex_meta.orth]
 
@@ -317,7 +317,7 @@ class Token(AbstractObject):
     @property
     def lang_(self):
         """Language of the parent document's vocabulary,
-            e.g. 'en_web_core_lm'.
+        e.g. 'en_web_core_lm'.
         """
         return self.doc.vocab.store[self.lex_meta.lang]
 
@@ -329,7 +329,7 @@ class Token(AbstractObject):
     @property
     def is_stop(self):
         """Whether the token is a stop word, i.e. part of a
-            stop list defined by the language data.
+        stop list defined by the language data.
         """
         return self.lex_meta.check_flag(Attributes.IS_STOP)
 

--- a/syfertext/tokenizer.py
+++ b/syfertext/tokenizer.py
@@ -25,7 +25,7 @@ from typing import Dict
 
 class TokenMeta(object):
     """This class holds some meta data about a token from the text held by a Doc object.
-       This allows to create a Token object when needed.
+    This allows to create a Token object when needed.
     """
 
     def __init__(self, hash_key: int, space_after: bool):
@@ -58,7 +58,7 @@ class Tokenizer(AbstractSendable):
         infix_finditer=infix_re.finditer,
     ):
         """Initializes the `Tokenizer` object
-           
+
         Args:
             vocab (str or Vocab object): If `str`, this should be the name of the
                 language model to build the `Vocab` object from, such as
@@ -67,7 +67,7 @@ class Tokenizer(AbstractSendable):
                 its `Vocab` object from scratch instead of sending the `Vocab`
                 object to the remote worker which might take too much network traffic.
             exceptions: Exception cases for the tokenizer.
-                Example: "e.g.", "Jr." 
+                Example: "e.g.", "Jr."
             prefix_search: A function matching the signature of
                 `re.compile(string).search` to match prefixes.
                 Example: "@username" : "@" is a prefix
@@ -103,7 +103,7 @@ class Tokenizer(AbstractSendable):
 
     def __call__(self, text: Union[String, str]):
         """The real tokenization procedure takes place here.
-        As in the spaCy library. This is not exactly equivalent to 
+        As in the spaCy library. This is not exactly equivalent to
         text.split(' '). Because tokens can be white spaces if two or
         more consecutive white spaces are found. Also, this tokenizer
         also takes affixes and exception cases into account.
@@ -113,7 +113,7 @@ class Tokenizer(AbstractSendable):
             'I  love apples ' gives four tokens: 'I', ' ', 'love', 'apples'
             ' I love ' gives three tokens: ' ', 'I', 'love' (yes a single white space
             at the beginning is considered a token)
-            'I love-apples' gives 4 tokens: 'I', 'love', '-', 'apples'(infix is 
+            'I love-apples' gives 4 tokens: 'I', 'love', '-', 'apples'(infix is
             tokenized seprately)
         Tokenizing this way helps reconstructing the original string
         without loss of white spaces.
@@ -222,17 +222,17 @@ class Tokenizer(AbstractSendable):
         return doc
 
     def _tokenize(self, substring: str, token_meta: TokenMeta, doc: Doc) -> Doc:
-        """ Tokenize each substring formed after splitting affixes and processing 
+        """Tokenize each substring formed after splitting affixes and processing
             exceptions. Returns Doc object.
 
         Args:
             substring: The substring to tokenize.
             token_meta: The TokenMeta object of original substring
                 before splitting affixes and exceptions.
-            doc: Document object. 
+            doc: Document object.
 
-        Returns:    
-            doc: Document with all the TokenMeta objects of every token after splitting 
+        Returns:
+            doc: Document with all the TokenMeta objects of every token after splitting
                 affixes and exceptions.
         """
 
@@ -261,10 +261,10 @@ class Tokenizer(AbstractSendable):
 
         Args:
             substring: The substring to tokenize.
-            
-        Returns:    
+
+        Returns:
             substring: The substring to tokenize.
-            affixes: Dict holding TokenMeta lists of each affix 
+            affixes: Dict holding TokenMeta lists of each affix
                 types as a result of splitting affixes
             exception_tokens: The list of exception tokens TokenMeta objects.
         """
@@ -336,18 +336,18 @@ class Tokenizer(AbstractSendable):
     ) -> Doc:
         """Attach all the `TokenMeta` objects which are the result of splitting affixes
         in Doc object's container. Returns Doc object.
-       
+
         Args:
             doc: Original Document
             substring: The substring remaining after splitting all the affixes.
-            space_after: If there is a space after the original substring before splitting any affixes 
+            space_after: If there is a space after the original substring before splitting any affixes
                 in the text.
-            affixes: Dict holding TokenMeta lists of each affix types(prefix, suffix, infix) 
+            affixes: Dict holding TokenMeta lists of each affix types(prefix, suffix, infix)
                 formed as the result of splitting affixes.
             exception_tokens: The list of TokenMeta object of exception tokens.
 
         Returns:
-            doc: Document with all the TokenMeta objects of every token after splitting 
+            doc: Document with all the TokenMeta objects of every token after splitting
                 affixes and exceptions.
         """
 
@@ -385,10 +385,10 @@ class Tokenizer(AbstractSendable):
 
         Args:
             substring: The substring to tokenize.
-            
+
         Returns:
             token_meta: The TokenMeta object with TokenMeta data of prefix.
-            substring: The updated substring after removing prefix.           
+            substring: The updated substring after removing prefix.
         """
 
         # Get the length of prefix match in the substring.
@@ -414,7 +414,7 @@ class Tokenizer(AbstractSendable):
 
         Args:
             substring: The `substring` to tokenize.
-            
+
         Returns:
             token_meta: The TokenMeta object of the suffix.
             substring: The updated substring after removing the suffix.
@@ -495,9 +495,9 @@ class Tokenizer(AbstractSendable):
 
         Args:
             substring: The substring to tokenize.
-            
+
         Returns:
-            exception_token_metas : the list of exceptions TokenMeta 
+            exception_token_metas : the list of exceptions TokenMeta
                 objects.
             substring: The updated substring after processing the exceptions.
 
@@ -525,13 +525,13 @@ class Tokenizer(AbstractSendable):
 
     def infix_matches(self, substring: str) -> List[Match]:
         """Find internal split points of the string, such as hyphens.
-        
+
         Args:
             substring : The string to segment.
 
         Returns:
             A list of `re.MatchObject` objects that have `.start()`
-                and `.end()` methods, denoting the placement of internal 
+                and `.end()` methods, denoting the placement of internal
                 segment separators, e.g. hyphens.
         """
 
@@ -549,7 +549,7 @@ class Tokenizer(AbstractSendable):
 
         Args:
             substring: The string to segment.
-            
+
         Returns:
             The length of the prefix if present, otherwise 0.
         """
@@ -588,7 +588,7 @@ class Tokenizer(AbstractSendable):
     @staticmethod
     def simplify(worker, tokenizer: "Tokenizer"):
         """This method is used to reduce a `Tokenizer` object into a list of simpler objects that can be
-           serialized.
+        serialized.
         """
 
         # Simplify attributes

--- a/syfertext/underscore.py
+++ b/syfertext/underscore.py
@@ -1,7 +1,7 @@
 class Underscore:
     """Objects of this class will hold custom attributes of Token
-       objects set using the `set_attribute` method of the Token
-       class
+    objects set using the `set_attribute` method of the Token
+    class
     """
 
     pass

--- a/syfertext/utils.py
+++ b/syfertext/utils.py
@@ -12,7 +12,7 @@ import shutil
 
 
 def hash_string(string: str) -> int:
-    """Create a hash for a given string. 
+    """Create a hash for a given string.
     Hashes created by this functions will be used everywhere by
     SyferText to represent tokens.
     """
@@ -88,7 +88,7 @@ def compile_prefix_regex(entries: Tuple) -> Pattern:
 
 def compile_suffix_regex(entries: Tuple) -> Pattern:
     """Compile a sequence of suffix rules into a regex object.
-    
+
     Args:
         entries (tuple): The suffix rules, e.g. syfertext.punctuation.TOKENIZER_SUFFIXES.
 

--- a/syfertext/vocab.py
+++ b/syfertext/vocab.py
@@ -61,7 +61,7 @@ class Vocab:
 
     def get_vector(self, key: Union[str, int]):
         """Retrieve a vector for a word in the vocabulary. Words can be looked
-        up by string or int ID. 
+        up by string or int ID.
 
         Args:
             key: The word hash, or its plaintext.
@@ -91,7 +91,7 @@ class Vocab:
         stored.
 
         Args:
-            key: The word hash, or its plaintext. 
+            key: The word hash, or its plaintext.
 
         Returns:
             Lexeme: The lexeme specified by the given key.
@@ -118,10 +118,10 @@ class Vocab:
 
     def has_vector(self, key: Union[str, int]) -> bool:
         """Check whether the given string has an entry in word vectors table
-        
+
         Args:
             key: The word or its hash for which the existence of a vector is to be checked out.
-        
+
         Returns :
             bool: True if a vector for 'word' already exists.
         """
@@ -131,7 +131,7 @@ class Vocab:
     def get_lex_meta(self, orth: int) -> Union[LexemeMeta]:
         """Get a LexemeMeta from the lexstore, creating a new
         Lexeme if necessary.
-        
+
         Args:
             orth: The word hash for which the LexemeMeta object is requested.
 
@@ -156,10 +156,10 @@ class Vocab:
 
     def _create_lex_meta(self, string: str) -> LexemeMeta:
         """Creates a LexemeMeta object corresponding to `string`.
-        
+
         Args:
             string: The plaintext string for which a LexemeMeta object is to be created.
-            
+
         Returns:
             A LexemeMeta object corresponding to `string`.
         """

--- a/tests/local_mode/test_span.py
+++ b/tests/local_mode/test_span.py
@@ -89,7 +89,7 @@ def test_span_of_span():
 
 def test_span_as_doc():
     """Test span is returned as Doc upon calling `as_doc()`
-     method of Span.
+    method of Span.
     """
     doc_ = nlp("the quick brown fox jumps over lazy dog")
 
@@ -110,8 +110,8 @@ def test_span_as_doc():
 
 def test_remote_span_as_remote_doc():
     """Test a pointer to Doc object with a copy of `Span`'s tokens
-     is returned upon calling `as_doc()` on a Span residing on a remote
-     machine.
+    is returned upon calling `as_doc()` on a Span residing on a remote
+    machine.
     """
 
     james = sy.VirtualWorker(hook, id="james")


### PR DESCRIPTION
## Description
Corrects the missing closing parenthesis in the introductory paragraph of the readme

## Affected Dependencies
None

## How has this been tested?
- Correction is rendered correctly in GitHub readme

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
