### PR TITLE
feat: Adds initial requirements.txt folder

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.22.0
+syfertext==0.1.0
+syft==0.2.8


### PR DESCRIPTION
## Description
Adds initial `requirements.txt` file in a `pip-dep` folder like PySyft after running `python setup.py install` in a clean virtual environment.

This would check-off one of the items in issue #171 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
By running the installation instructions

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
