### PR TITLE
Persist pipeline and states remotely, updated get_copy

### DIFF
--- a/syfertext/pipeline/pointers/pipeline_pointer.py
+++ b/syfertext/pipeline/pointers/pipeline_pointer.py
@@ -48,17 +48,8 @@ class PipelinePointer(ObjectPointer):
                 object referenced by this pointer.
         """
 
-        # Send the command, this will creates a copy of pipeline on remote location
-        self.owner.send_command(
-            recipient=self.location,
-            cmd_name="send_copy",
-            target=self,
-            args_=tuple(),
-            kwargs_={"destination": self.owner},
-        )
-
         # Request the pipeline from the remote worker
-        pipeline = self.owner.request_obj(self.id_at_location, self.location)
+        pipeline = self.owner.request_obj(self.id_at_location, self.location, get_copy=True)
 
         # Register it in the object store
         self.owner.register_obj(pipeline)

--- a/syfertext/pointers/state_pointer.py
+++ b/syfertext/pointers/state_pointer.py
@@ -47,17 +47,8 @@ class StatePointer(ObjectPointer):
                 object referenced by this pointer.
         """
 
-        # Send the command
-        self.owner.send_command(
-            recipient=self.location,
-            cmd_name="send_copy",
-            target=self,
-            args_=tuple(),
-            kwargs_={"destination": self.owner},
-        )
-
         # Request the state from the remote worker
-        state = self.owner.request_obj(self.id_at_location, self.location)
+        state = self.owner.request_obj(self.id_at_location, self.location, get_copy=True)
 
         # Register it in the object store
         self.owner.register_obj(state)


### PR DESCRIPTION
## Description
To Persist pipeline remotely, updated get_copy functions in state and pipeline pointers, this change is in consideration after my latest change in PySyft `get()` method https://github.com/OpenMined/PySyft/pull/4633 where new `get_copy` argument is added in `get()` method and related functions for getting objects without removing the remote object.

## Affected Dependencies
none

## How has this been tested?
Not covered

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
