### PR TITLE
fix for vector shapes

### DIFF
--- a/syfertext/doc.py
+++ b/syfertext/doc.py
@@ -212,7 +212,7 @@ class Doc(AbstractObject):
         ), "One of the provided vectors has a zero norm!"
 
         # Compute similarity
-        sim = torch.dot(torch.tensor(self.vector), torch.tensor(other.vector))
+        sim = torch.matmul(self.vector, other.vector.transpose(1, 0))
         sim /= self.vector_norm * other.vector_norm
 
         return sim

--- a/syfertext/token.py
+++ b/syfertext/token.py
@@ -197,7 +197,7 @@ class Token(AbstractObject):
         ), "One of the provided tokens has a zero norm."
 
         # Compute similarity
-        sim = torch.dot(torch.tensor(self.vector), torch.tensor(other.vector))
+        sim = torch.matmul(self.vector, other.vector.transpose(1, 0))
         sim /= self.vector_norm * other.vector_norm
 
         return sim

--- a/syfertext/vectors.py
+++ b/syfertext/vectors.py
@@ -35,7 +35,7 @@ class Vectors:
         # Create the default vector as a numpy array if the `vectors` property is
         # set.
         if self.vectors is not None:
-            self.default_vector = torch.zeros(self.vectors.shape[1], dtype=torch.float)
+            self.default_vector = torch.zeros((1, self.vectors.shape[1]), dtype=torch.float)
 
     def load_data(self, hash2row: Dict[int, int], vectors: Union[np.ndarray, torch.tensor]):
         """Loads the vector data. This is needed when the Vocab object loads its
@@ -116,5 +116,8 @@ class Vectors:
 
         # Get the vector
         vector = self.vectors[row]
+
+        # Make it a 2D vector of size (1, nb coefficients)
+        vector = vector.unsqueeze(0)
 
         return vector

--- a/tests/local_mode/test_doc.py
+++ b/tests/local_mode/test_doc.py
@@ -200,13 +200,12 @@ def test_exclude_tokens_on_attr_values_doc():
     # initialize the excluded_tokens dict
     excluded_tokens = {"attribute1_name": {"value1", "value2"}, "attribute2_name": {"v1", "v2"}}
 
-    # checks if get_vector returns the same vector for doc and the doc with the word to exclude already missing,
-    # all() is needed because equals for tensor arrays returns an array of booleans.
-    assert all(doc.get_vector(excluded_tokens) == doc_excluding_tokens.get_vector())
+    # checks if get_vector returns the same vector for doc and the doc with the word to exclude already missing.
+    assert torch.equal(doc.get_vector(excluded_tokens), doc_excluding_tokens.get_vector())
 
     # checks if get_vector without excluded_tokens returns a different vector for doc
     # and doc with the word to exclude already missing.
-    assert any(doc.get_vector() != doc_excluding_tokens.get_vector())
+    assert not torch.equal(doc.get_vector(), doc_excluding_tokens.get_vector())
 
 
 def test_get_token_vectors():


### PR DESCRIPTION
## Description
When returning a single vector in the `__getitem__` method of the `Vector` class, the tensor should be of shape (1, <number of coefficient>) rather than (<number of coefficient>,).

This fix is necessary for correct functionality of torch ops such as applying a linear layer in inference.

