### PR TITLE
Remove state objects from pipeline 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v1
       with:
-        python-version: '>=3.7'
+        python-version: '3.7'
     - name: Install SyferText with test dependencies
       run: |
         pip install ".[test]"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "tqdm==4.36.1",
         "mmh3==2.5.1",
-        "syft @ git+https://github.com/Nilanshrajput/PySyft.git@GridClients_Serialize_correction#egg=syft",
+        "syft @ git+https://github.com/OpenMined/PySyft#egg=syft",
         "requests==2.22.0",
     ],
     extras_require={

--- a/syfertext/__init__.py
+++ b/syfertext/__init__.py
@@ -64,7 +64,7 @@ def load(pipeline_name: str) -> Language:
     nlp.deployed_on = deployed_on
 
     # Load the pipeline into the Language object
-    nlp.load_pipeline(template=pipeline.template, states=pipeline.states)
+    nlp.load_pipeline(template=pipeline.template, states_info=pipeline.states_info)
 
     return nlp
 

--- a/syfertext/language.py
+++ b/syfertext/language.py
@@ -588,7 +588,7 @@ class Language(AbstractObject):
 
             # Remove the state objects as its not required.
             # Only description of each state needed to reconstruct the pipeline
-            states[pipe_name].pop('states')
+            states[pipe_name].pop("states")
 
         # Create a Pipeline object
         pipeline = Pipeline(

--- a/syfertext/language.py
+++ b/syfertext/language.py
@@ -54,10 +54,10 @@ class Language(AbstractObject):
         # of the pipeline, an object that is charged to accomplish the job.
         self.factories = dict()
 
-        # Initialize an empty dict of State object.
+        # Initialize an empty dict for storing info about each State object.
         # The keys of this dict are the names of the components
-        # whose states are being stored, e.g., 'vocab', 'stopword_tagger', etc.
-        self.states = {}
+        # whose description of states are being stored, e.g., 'vocab', 'stopword_tagger', etc.
+        self.states_info = {}
 
         # Initialize the property that should hold the subpipeline templates
         # list for each worker
@@ -136,10 +136,28 @@ class Language(AbstractObject):
 
         self._save_state(state=state, name=vocab.name, access=access)
 
-    def load_pipeline(self, template, states):
+    def load_pipeline(self, template: List[dict], states_info: Dict[str, dict]) -> None:
+        """Loads the pipeline from the given template in Langauage object.
 
-        # Load the states
-        self.states = states
+        Args:
+            template: A list of dictionaries each describing
+                a pipe component of the pipeline in order.
+            states_info: a dictionary of dictionaries containing the
+                description of each state needed to reconstruct
+                the pipeline. Example:
+                    {'tokenizer': {'location_id': 'bob',
+                                   'access': {'*'},
+                                  },
+                     'vocab': {'location_id': 'bob',
+                               'access', {'*'},
+                              }
+                     :
+                     :
+                    }
+        """
+
+        # Load the states info
+        self.states_info = states_info
 
         # Load the pipeline template
         self.pipeline_template = template
@@ -168,7 +186,7 @@ class Language(AbstractObject):
         """
 
         # Add to the list of State objects known to this Language object
-        self.states[name] = dict(state=state, access=access)
+        self.states_info[name] = dict(access=access)
 
         # Register it in the object store
         self.owner.register_obj(state)
@@ -212,7 +230,7 @@ class Language(AbstractObject):
             # If it does, append the pipe template to the currently
             # processed subpipeline template
             # The reason I use .get() here is just for better code lisibility
-            access = self.states.get(pipe_template["name"]).get("access")
+            access = self.states_info.get(pipe_template["name"]).get("access")
 
             if {"*", location_id} & access:
 
@@ -579,22 +597,18 @@ class Language(AbstractObject):
 
         # Set the `location_id` property of each state to
         # the worker on which the pipeline is deployed
-        states = self.states.copy()
+        states_info = self.states_info.copy()
 
-        for pipe_name in self.states:
+        for pipe_name in self.states_info:
 
             # Change the pipe's location
-            states[pipe_name]["location_id"] = worker.id
-
-            # Remove the state objects as its not required.
-            # Only description of each state needed to reconstruct the pipeline
-            states[pipe_name].pop("states")
+            states_info[pipe_name]["location_id"] = worker.id
 
         # Create a Pipeline object
         pipeline = Pipeline(
             name=self.pipeline_name,
             template=self.pipeline_template,
-            states=states,
+            states_info=states_info,
             owner=self.owner,
             tags=self.tags,
             description=self.description,

--- a/syfertext/language.py
+++ b/syfertext/language.py
@@ -586,6 +586,10 @@ class Language(AbstractObject):
             # Change the pipe's location
             states[pipe_name]["location_id"] = worker.id
 
+            # Remove the state objects as its not required.
+            # Only description of each state needed to reconstruct the pipeline
+            states[pipe_name].pop('states')
+
         # Create a Pipeline object
         pipeline = Pipeline(
             name=self.pipeline_name,

--- a/syfertext/pipeline/pipeline.py
+++ b/syfertext/pipeline/pipeline.py
@@ -25,7 +25,7 @@ class Pipeline(AbstractSendable):
         self,
         name: str,
         template: List[dict],
-        states: Dict[str, dict],
+        states_info: Dict[str, dict],
         owner: BaseWorker = None,
         tags: Set[str] = None,
         description: str = None,
@@ -39,7 +39,7 @@ class Pipeline(AbstractSendable):
                 PyGrid.
             template: A list of dictionaries each describing
                 a pipe component of the pipeline in order.
-            states: a dictionary of dictionaries containing the
+            states_info: a dictionary of dictionaries containing the
                 description of each state needed to reconstruct
                 the pipeline. Example:
                     {'tokenizer': {'location_id': 'bob',
@@ -66,7 +66,7 @@ class Pipeline(AbstractSendable):
 
         # Create properties
         self.template = template
-        self.states = states
+        self.states_info = states_info
 
         # Initialize the parent class
         super(Pipeline, self).__init__(id=id, owner=owner, tags=tags, description=description)
@@ -77,10 +77,10 @@ class Pipeline(AbstractSendable):
         """
 
         # Loop through all the states
-        for state_name in self.states:
+        for state_name in self.states_info:
 
             # Get the name of the state
-            location_id = self.states[state_name]["location_id"]
+            location_id = self.states_info[state_name]["location_id"]
 
             # Construct the state ID that will be used as the search query
             state_id = create_state_query(pipeline_name=self.name, state_name=state_name)
@@ -111,7 +111,7 @@ class Pipeline(AbstractSendable):
         pipeline = Pipeline(
             name=self.name,
             template=self.template,
-            states=self.states,
+            states_info=self.states_info,
             owner=self.owner,
             tags=self.tags,
             description=self.description,
@@ -205,7 +205,7 @@ class Pipeline(AbstractSendable):
         # Simplify the Pipeline object attributes
         name_simple = serde._simplify(worker, pipeline.name)
         template_simple = serde._simplify(worker, pipeline.template)
-        states_simple = serde._simplify(worker, pipeline.states)
+        states_info_simple = serde._simplify(worker, pipeline.states_info)
         tags_simple = serde._simplify(worker, pipeline.tags)
         description_simple = serde._simplify(worker, pipeline.description)
 
@@ -213,7 +213,7 @@ class Pipeline(AbstractSendable):
         pipeline_simple = (
             name_simple,
             template_simple,
-            states_simple,
+            states_info_simple,
             tags_simple,
             description_simple,
         )
@@ -240,7 +240,7 @@ class Pipeline(AbstractSendable):
         (
             name_simple,
             template_simple,
-            states_simple,
+            states_info_simple,
             tags_simple,
             description_simple,
         ) = pipeline_simple
@@ -248,7 +248,7 @@ class Pipeline(AbstractSendable):
         # Detail the attributes
         name = serde._detail(worker, name_simple)
         template = serde._detail(worker, template_simple)
-        states = serde._detail(worker, states_simple)
+        states_info = serde._detail(worker, states_info_simple)
         tags = serde._detail(worker, tags_simple)
         description = serde._detail(worker, description_simple)
 
@@ -256,7 +256,7 @@ class Pipeline(AbstractSendable):
         pipeline = Pipeline(
             name=name,
             template=template,
-            states=states,
+            states_info=states_info,
             owner=worker,
             tags=tags,
             description=description,


### PR DESCRIPTION
## Description
remove state objects from pipeline only description dictionary of dictionaries containing the description of each state needed to reconstruct the pipeline.
Also updated the pysyft to master branch(0.2.9)
Fixed python = 3.7 in CI build
## Affected Dependencies
none

## How has this been tested?


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
