### PR TITLE
Fixed issue #201 (Installation Error #201) (change syft==0.4.0 to syft==0.3.0 in setup.py)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(),
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    install_requires=["tqdm==4.36.1", "mmh3==2.5.1", "requests==2.22.0", "syft==0.4.0"],
+    install_requires=["tqdm==4.36.1", "mmh3==2.5.1", "requests==2.22.0", "syft==0.3.0"],
     extras_require={
         "test": [
             "black>=20.8b1",


### PR DESCRIPTION
## Description

Fixing a small bug in setup.py. **python setup.py install** was giving an error "error: Could not find suitable distribution for Requirement.parse('syft==0.4.0')", which was due to the incorrect version of syft. The issue has been solved by mentioning the latest version of syft i.e. 0.3.0 as of [here](https://pypi.org/project/syft/#history).  This PR solves [Installation Error #201](https://github.com/OpenMined/SyferText/issues/201).

## How has this been tested?
- The installation process was tested on colab which can be found [here](https://colab.research.google.com/drive/1xCSwWXEC8TDb4XgMYkpbE04lq3Sa5M0L?usp=sharing)


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
